### PR TITLE
implement findex needs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 
 ---
+## [1.1.0] - 2022-08-16
+### Added
+- Add `SymKey` trait to add `as_byte()` method
+- add `Zeroize` as `KeyTrait` super trait
+### Changed
+- Pass output length as a constant generic to the HKDF
+### Fixed
+- typos in doc
+### Removed
+---
+
+---
 ## [1.0.1] - 2022-08-02
 ### Added
 - Add `PartialEq + Eq` as `KeyTrait` super trait

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Crypto lib for pure crypto primitives"
 edition = "2021"
 license = "MIT/Apache-2.0"
 name = "cosmian_crypto_core"
-version = "1.0.1"
+version = "1.1.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/src/asymmetric_crypto.rs
+++ b/src/asymmetric_crypto.rs
@@ -346,6 +346,12 @@ impl<'a> Mul<&'a X25519PrivateKey> for X25519PublicKey {
     }
 }
 
+impl Zeroize for X25519PublicKey {
+    fn zeroize(&mut self) {
+        self.0.zeroize()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::{

--- a/src/kdf.rs
+++ b/src/kdf.rs
@@ -14,7 +14,7 @@ pub fn hkdf_256<const KEY_LENGTH: usize>(
 ) -> Result<[u8; KEY_LENGTH], CryptoCoreError> {
     if bytes.len() < 32 {
         return Err(CryptoCoreError::InvalidSize(
-            "Input `bytes` should be of length at least 32".to_string(),
+            "Input `bytes` size should be at least 32".to_string(),
         ));
     }
     let h = Hkdf::<Sha256>::new(None, bytes);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,10 +18,12 @@ pub mod entropy;
 pub mod kdf;
 pub mod symmetric_crypto;
 
+use zeroize::Zeroize;
+
 pub use crate::error::CryptoCoreError;
 
 /// Trait defining a cryptographic key.
-pub trait KeyTrait: PartialEq + Eq + Send + Sync + Sized + Clone {
+pub trait KeyTrait: PartialEq + Eq + Send + Sync + Sized + Clone + Zeroize {
     /// Number of bytes in the serialized key.
     const LENGTH: usize;
 

--- a/src/symmetric_crypto/aes_256_gcm_pure/mod.rs
+++ b/src/symmetric_crypto/aes_256_gcm_pure/mod.rs
@@ -2,14 +2,15 @@
 //! algorithm.
 //!
 //! It will use the AES native interface on the CPU if available.
-use crate::{symmetric_crypto::SymmetricCrypto, CryptoCoreError};
+use crate::{
+    symmetric_crypto::{nonce::NonceTrait, SymKey, SymmetricCrypto},
+    CryptoCoreError,
+};
 use aes_gcm::{
     aead::{generic_array::GenericArray, Aead, NewAead, Payload},
     AeadInPlace, Aes256Gcm,
 };
 use std::{fmt::Display, vec::Vec};
-
-use super::nonce::NonceTrait;
 
 pub mod dem;
 
@@ -81,7 +82,7 @@ pub fn encrypt_combined(
     nonce: &Nonce,
     additional_data: Option<&[u8]>,
 ) -> Result<Vec<u8>, CryptoCoreError> {
-    let cipher = Aes256Gcm::new(GenericArray::from_slice(key.as_slice()));
+    let cipher = Aes256Gcm::new(GenericArray::from_slice(key.as_bytes()));
     let payload =
         additional_data.map_or_else(|| Payload::from(bytes), |aad| Payload { msg: bytes, aad });
     cipher
@@ -100,7 +101,7 @@ pub fn encrypt_in_place_detached(
     nonce: &Nonce,
     additional_data: Option<&[u8]>,
 ) -> Result<Vec<u8>, CryptoCoreError> {
-    let cipher = Aes256Gcm::new(GenericArray::from_slice(key.as_slice()));
+    let cipher = Aes256Gcm::new(GenericArray::from_slice(key.as_bytes()));
     let additional_data = additional_data.unwrap_or_default();
     cipher
         .encrypt_in_place_detached(
@@ -124,7 +125,7 @@ pub fn decrypt_combined(
     nonce: &Nonce,
     additional_data: Option<&[u8]>,
 ) -> Result<Vec<u8>, CryptoCoreError> {
-    let cipher = Aes256Gcm::new(GenericArray::from_slice(key.as_slice()));
+    let cipher = Aes256Gcm::new(GenericArray::from_slice(key.as_bytes()));
     let payload =
         additional_data.map_or_else(|| Payload::from(bytes), |aad| Payload { msg: bytes, aad });
     cipher
@@ -146,7 +147,7 @@ pub fn decrypt_in_place_detached(
     nonce: &Nonce,
     additional_data: Option<&[u8]>,
 ) -> Result<(), CryptoCoreError> {
-    let cipher = Aes256Gcm::new(GenericArray::from_slice(key.as_slice()));
+    let cipher = Aes256Gcm::new(GenericArray::from_slice(key.as_bytes()));
     let additional_data = additional_data.unwrap_or_default();
     cipher
         .decrypt_in_place_detached(

--- a/src/symmetric_crypto/key.rs
+++ b/src/symmetric_crypto/key.rs
@@ -1,6 +1,6 @@
 //! Define a symmetric key object of variable size.
 
-use crate::{CryptoCoreError, KeyTrait};
+use crate::{symmetric_crypto::SymKey, CryptoCoreError, KeyTrait};
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -24,11 +24,6 @@ impl<const KEY_LENGTH: usize> Key<KEY_LENGTH> {
         rng.fill_bytes(&mut key.0);
         key
     }
-
-    /// Convert the given key into a byte slice, without copy.
-    pub const fn as_slice(&self) -> &[u8] {
-        &self.0
-    }
 }
 
 impl<const KEY_LENGTH: usize> Default for Key<KEY_LENGTH> {
@@ -42,12 +37,19 @@ impl<const KEY_LENGTH: usize> KeyTrait for Key<KEY_LENGTH> {
 
     /// Convert the given key into bytes, with copy.
     fn to_bytes(&self) -> Vec<u8> {
-        self.as_slice().to_vec()
+        self.as_bytes().to_vec()
     }
 
     /// Try to convert the given bytes into a key. Size must be correct.
     fn try_from_bytes(bytes: &[u8]) -> Result<Self, CryptoCoreError> {
         Self::try_from(bytes)
+    }
+}
+
+impl<const KEY_LENGTH: usize> SymKey for Key<KEY_LENGTH> {
+    /// Convert the given key into a byte slice, without copy.
+    fn as_bytes(&self) -> &[u8] {
+        &self.0
     }
 }
 
@@ -117,7 +119,11 @@ impl<const KEY_LENGTH: usize> Drop for Key<KEY_LENGTH> {
 #[cfg(test)]
 mod tests {
 
-    use crate::{entropy::CsRng, symmetric_crypto::key::Key, KeyTrait};
+    use crate::{
+        entropy::CsRng,
+        symmetric_crypto::{key::Key, SymKey},
+        KeyTrait,
+    };
 
     const KEY_LENGTH: usize = 128;
 
@@ -125,9 +131,9 @@ mod tests {
     fn test_key() {
         let mut cs_rng = CsRng::new();
         let key_1 = Key::<KEY_LENGTH>::new(&mut cs_rng);
-        assert_eq!(KEY_LENGTH, key_1.as_slice().len());
+        assert_eq!(KEY_LENGTH, key_1.as_bytes().len());
         let key_2 = Key::new(&mut cs_rng);
-        assert_eq!(KEY_LENGTH, key_2.as_slice().len());
+        assert_eq!(KEY_LENGTH, key_2.as_bytes().len());
         assert_ne!(key_1, key_2);
     }
 

--- a/src/symmetric_crypto/key.rs
+++ b/src/symmetric_crypto/key.rs
@@ -31,6 +31,12 @@ impl<const KEY_LENGTH: usize> Key<KEY_LENGTH> {
     }
 }
 
+impl<const KEY_LENGTH: usize> Default for Key<KEY_LENGTH> {
+    fn default() -> Self {
+        Self([0; KEY_LENGTH])
+    }
+}
+
 impl<const KEY_LENGTH: usize> KeyTrait for Key<KEY_LENGTH> {
     const LENGTH: usize = KEY_LENGTH;
 

--- a/src/symmetric_crypto/mod.rs
+++ b/src/symmetric_crypto/mod.rs
@@ -17,11 +17,17 @@ use nonce::NonceTrait;
 use rand_core::{CryptoRng, RngCore};
 use std::vec::Vec;
 
+/// Defines a symmetric encrytion key.
+pub trait SymKey: KeyTrait {
+    /// Convert the given key into a byte slice.
+    fn as_bytes(&self) -> &[u8];
+}
+
 /// Defines a symmetric encryption scheme. If this scheme is authenticated,
 /// the `MAC_LENGTH` will be greater than `0`.
 pub trait SymmetricCrypto: Send + Sync {
     const MAC_LENGTH: usize;
-    type Key: KeyTrait;
+    type Key: SymKey;
     type Nonce: NonceTrait;
 
     /// A short description of the scheme

--- a/src/symmetric_crypto/mod.rs
+++ b/src/symmetric_crypto/mod.rs
@@ -17,7 +17,7 @@ use nonce::NonceTrait;
 use rand_core::{CryptoRng, RngCore};
 use std::vec::Vec;
 
-/// Defines a symmetric encrytion key.
+/// Defines a symmetric encryption key.
 pub trait SymKey: KeyTrait {
     /// Convert the given key into a byte slice.
     fn as_bytes(&self) -> &[u8];
@@ -58,7 +58,7 @@ pub trait SymmetricCrypto: Send + Sync {
 
     /// Decrypts a message in combined mode.
     ///
-    /// Attemps to read a MAC appended to the ciphertext. The provided
+    /// Attempts to read a MAC appended to the ciphertext. The provided
     /// additional data must match those provided during encryption for the
     /// MAC to verify. Decryption will never be performed, even partially,
     /// before verification.


### PR DESCRIPTION
Needed in [findex#11](http://gitlab.cosmian.com/core/findex/-/merge_requests/11):
- add `Zeroize` super traits for `KeyTrait`
- add `SymKey` trait to allow cheap `as_byte()` operation on symmetric keys
- use the output size as a constant generic in the KDF implementation.