### PR TITLE
Add Hash as `SymKey` super trait.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 
 ---
+## [2.0.1] - 2022-09-02
+### Added
+- `Hash` super trait to `SymKey`
+### Changed
+### Fixed
+### Removed
+---
+
+---
 ## [2.0.0] - 2022-08-22
 ### Added
 - `Eq` super trait to `KeyTrait`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "cosmian_crypto_core"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "aes 0.8.1",
  "aes-gcm",
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1079fb8528d9f9c888b1e8aa651e6e079ade467323d58f75faf1d30b1808f540"
+checksum = "dc948ebb96241bb40ab73effeb80d9f93afaad49359d159a5e61be51619fe813"
 dependencies = [
  "libc",
 ]
@@ -434,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+checksum = "899bf02746a2c92bf1053d9327dadb252b01af1f81f90cdb902411f518bc7215"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -462,18 +462,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
+checksum = "3d0a539a918745651435ac7db7a18761589a94cd7e94cd56999f828bf73c8a57"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
+checksum = "c251e90f708e16c49a16f4917dc2131e75222b72edfa9cb7f7c58ae56aae0c09"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Crypto lib for pure crypto primitives"
 edition = "2021"
 license = "MIT/Apache-2.0"
 name = "cosmian_crypto_core"
-version = "2.0.0"
+version = "2.0.1"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/src/symmetric_crypto/key.rs
+++ b/src/symmetric_crypto/key.rs
@@ -4,7 +4,7 @@ use crate::{symmetric_crypto::SymKey, CryptoCoreError, KeyTrait};
 use aes::cipher::generic_array::{ArrayLength, GenericArray};
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use std::{convert::TryFrom, fmt::Display, ops::Deref};
+use std::{convert::TryFrom, fmt::Display, hash::Hash, ops::Deref};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// Symmetric key of a given size.
@@ -36,7 +36,7 @@ impl<KeyLength: Eq + ArrayLength<u8>> KeyTrait for Key<KeyLength> {
     }
 }
 
-impl<KeyLength: Eq + ArrayLength<u8>> SymKey for Key<KeyLength> {
+impl<KeyLength: Hash + Eq + ArrayLength<u8>> SymKey for Key<KeyLength> {
     /// Convert the given key into a byte slice, without copy.
     fn as_bytes(&self) -> &[u8] {
         &self.0

--- a/src/symmetric_crypto/mod.rs
+++ b/src/symmetric_crypto/mod.rs
@@ -17,10 +17,11 @@ use crate::{CryptoCoreError, KeyTrait};
 use generic_array::GenericArray;
 use nonce::NonceTrait;
 use rand_core::{CryptoRng, RngCore};
+use std::hash::Hash;
 use std::vec::Vec;
 
 /// Defines a symmetric encryption key.
-pub trait SymKey: KeyTrait {
+pub trait SymKey: KeyTrait + Hash {
     /// Convert the given key into a byte slice.
     fn as_bytes(&self) -> &[u8];
 


### PR DESCRIPTION
This allows simplifying trait bounds in CoverCrypt. Plus a symmetric key is essentially just a vector of bytes. It is natural to make it hashable.