### PR TITLE
Add KDF back!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 
 ---
+## [3.1.0] - 2022-10-06
+### Added
+- SHAKE256-based KDF
+- inline directives
+### Changed
+### Fixed
+### Removed
+---
+
+---
 ## [3.0.0] - 2022-10-04
 ### Added
 - `DhKeyPair` which represents an asymmetric key pair in a space wher the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,6 @@ dependencies = [
  "rand_core 0.6.4",
  "rand_hc",
  "serde",
- "sha2",
  "sha3",
  "thiserror",
  "zeroize",
@@ -328,17 +327,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.5",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "cosmian_crypto_core"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -347,9 +347,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
+checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,11 +82,11 @@ dependencies = [
  "curve25519-dalek",
  "getrandom 0.2.7",
  "hex",
- "hkdf",
  "rand_core 0.6.4",
  "rand_hc",
  "serde",
  "sha2",
+ "sha3",
  "thiserror",
  "zeroize",
 ]
@@ -150,7 +150,6 @@ checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
 dependencies = [
  "block-buffer",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -204,24 +203,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hkdf"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
-dependencies = [
- "hmac",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.5",
-]
-
-[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +219,12 @@ checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "keccak"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 
 [[package]]
 name = "libc"
@@ -352,6 +339,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.5",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2904bea16a1ae962b483322a1c7b81d976029203aea1f461e51cd7705db7ba9"
+dependencies = [
+ "digest 0.10.5",
+ "keccak",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,12 @@ curve25519-dalek = "3.2"
 # specify the js feature for the WASM target
 getrandom = { version = "0.2", features = ["js"] }
 hex = "0.4"
-hkdf = "0.12"
 rand_core = { version = "0.6", features = ["std", "getrandom"] }
 rand_hc = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
 thiserror = "1.0"
 zeroize = "1.5"
+
+[dev-dependencies]
+sha3 = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ hex = "0.4"
 rand_core = { version = "0.6", features = ["std", "getrandom"] }
 rand_hc = "0.3"
 serde = { version = "1.0", features = ["derive"] }
-sha2 = "0.10"
 thiserror = "1.0"
 zeroize = "1.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Crypto lib for pure crypto primitives"
 edition = "2021"
 license = "MIT/Apache-2.0"
 name = "cosmian_crypto_core"
-version = "3.0.0"
+version = "3.1.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/src/asymmetric_crypto/curve25519.rs
+++ b/src/asymmetric_crypto/curve25519.rs
@@ -16,7 +16,7 @@ use curve25519_dalek::{
     ristretto::{CompressedRistretto, RistrettoPoint},
     scalar::Scalar,
 };
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
@@ -45,7 +45,7 @@ impl X25519PrivateKey {
 impl KeyTrait<X25519_SK_LENGTH> for X25519PrivateKey {
     /// Generates a new random key.
     #[inline]
-    fn new<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+    fn new<R: CryptoRngCore>(rng: &mut R) -> Self {
         let mut bytes = [0; 64];
         rng.fill_bytes(&mut bytes);
         Self(Scalar::from_bytes_mod_order_wide(&bytes))
@@ -181,7 +181,7 @@ pub struct X25519PublicKey(RistrettoPoint);
 impl KeyTrait<X25519_PK_LENGTH> for X25519PublicKey {
     /// Generates a new random public key.
     #[inline]
-    fn new<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+    fn new<R: CryptoRngCore>(rng: &mut R) -> Self {
         let mut uniform_bytes = [0u8; 64];
         rng.fill_bytes(&mut uniform_bytes);
         Self(RistrettoPoint::from_uniform_bytes(&uniform_bytes))
@@ -323,7 +323,7 @@ impl DhKeyPair<X25519_PK_LENGTH, X25519_SK_LENGTH> for X25519KeyPair {
     type PrivateKey = X25519PrivateKey;
 
     #[inline]
-    fn new<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+    fn new<R: CryptoRngCore>(rng: &mut R) -> Self {
         let sk = X25519PrivateKey::new(rng);
         let pk = X25519PublicKey::from(&sk);
         Self { sk, pk }

--- a/src/asymmetric_crypto/curve25519.rs
+++ b/src/asymmetric_crypto/curve25519.rs
@@ -67,6 +67,7 @@ impl KeyTrait<X25519_SK_LENGTH> for X25519PrivateKey {
 impl TryFrom<[u8; Self::LENGTH]> for X25519PrivateKey {
     type Error = CryptoCoreError;
 
+    #[inline]
     fn try_from(bytes: [u8; Self::LENGTH]) -> Result<Self, Self::Error> {
         let scalar = Scalar::from_canonical_bytes(bytes).ok_or_else(|| {
             Self::Error::ConversionError(
@@ -80,14 +81,10 @@ impl TryFrom<[u8; Self::LENGTH]> for X25519PrivateKey {
 impl TryFrom<&[u8]> for X25519PrivateKey {
     type Error = CryptoCoreError;
 
+    #[inline]
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        let bytes: [u8; Self::LENGTH] = bytes.try_into().map_err(|e| {
-            Self::Error::ConversionError(format!(
-                "Error while converting slice of size {} to `X25519PublicKey`: {}",
-                bytes.len(),
-                e,
-            ))
-        })?;
+        let bytes = <[u8; Self::LENGTH]>::try_from(bytes)
+            .map_err(|e| Self::Error::ConversionError(e.to_string()))?;
         Self::try_from(bytes)
     }
 }
@@ -105,6 +102,7 @@ impl From<X25519PrivateKey> for [u8; X25519_SK_LENGTH] {
 impl TryFrom<&str> for X25519PrivateKey {
     type Error = CryptoCoreError;
 
+    #[inline]
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         let bytes = hex::decode(value)?;
         Self::try_from(bytes.as_slice())
@@ -121,6 +119,7 @@ impl Display for X25519PrivateKey {
 impl<'a> Add<&'a X25519PrivateKey> for &X25519PrivateKey {
     type Output = X25519PrivateKey;
 
+    #[inline]
     fn add(self, rhs: &X25519PrivateKey) -> Self::Output {
         X25519PrivateKey(self.0 + rhs.0)
     }
@@ -129,6 +128,7 @@ impl<'a> Add<&'a X25519PrivateKey> for &X25519PrivateKey {
 impl<'a> Sub<&'a X25519PrivateKey> for &X25519PrivateKey {
     type Output = X25519PrivateKey;
 
+    #[inline]
     fn sub(self, rhs: &X25519PrivateKey) -> Self::Output {
         X25519PrivateKey(self.0 - rhs.0)
     }
@@ -137,6 +137,7 @@ impl<'a> Sub<&'a X25519PrivateKey> for &X25519PrivateKey {
 impl<'a> Mul<&'a X25519PrivateKey> for &X25519PrivateKey {
     type Output = X25519PrivateKey;
 
+    #[inline]
     fn mul(self, rhs: &X25519PrivateKey) -> Self::Output {
         X25519PrivateKey(self.0 * rhs.0)
     }
@@ -145,6 +146,7 @@ impl<'a> Mul<&'a X25519PrivateKey> for &X25519PrivateKey {
 impl<'a> Div<&'a X25519PrivateKey> for &X25519PrivateKey {
     type Output = X25519PrivateKey;
 
+    #[inline]
     fn div(self, rhs: &X25519PrivateKey) -> Self::Output {
         #[allow(clippy::suspicious_arithmetic_impl)]
         X25519PrivateKey(self.0 * rhs.0.invert())
@@ -152,6 +154,7 @@ impl<'a> Div<&'a X25519PrivateKey> for &X25519PrivateKey {
 }
 
 impl Zeroize for X25519PrivateKey {
+    #[inline]
     fn zeroize(&mut self) {
         self.0.zeroize();
     }
@@ -159,6 +162,7 @@ impl Zeroize for X25519PrivateKey {
 
 // Implements `Drop` trait to follow R23.
 impl Drop for X25519PrivateKey {
+    #[inline]
     fn drop(&mut self) {
         self.zeroize();
     }
@@ -197,12 +201,14 @@ impl KeyTrait<X25519_PK_LENGTH> for X25519PublicKey {
 }
 
 impl From<X25519PrivateKey> for X25519PublicKey {
+    #[inline]
     fn from(private_key: X25519PrivateKey) -> Self {
         Self(&private_key.0 * &constants::RISTRETTO_BASEPOINT_TABLE)
     }
 }
 
 impl From<&X25519PrivateKey> for X25519PublicKey {
+    #[inline]
     fn from(private_key: &X25519PrivateKey) -> Self {
         Self(&private_key.0 * &constants::RISTRETTO_BASEPOINT_TABLE)
     }
@@ -211,6 +217,7 @@ impl From<&X25519PrivateKey> for X25519PublicKey {
 impl TryFrom<[u8; Self::LENGTH]> for X25519PublicKey {
     type Error = CryptoCoreError;
 
+    #[inline]
     fn try_from(bytes: [u8; Self::LENGTH]) -> Result<Self, Self::Error> {
         Ok(Self(CompressedRistretto(bytes).decompress().ok_or_else(
             || {
@@ -225,14 +232,10 @@ impl TryFrom<[u8; Self::LENGTH]> for X25519PublicKey {
 impl TryFrom<&[u8]> for X25519PublicKey {
     type Error = CryptoCoreError;
 
+    #[inline]
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        let bytes: [u8; Self::LENGTH] = bytes.try_into().map_err(|e| {
-            Self::Error::ConversionError(format!(
-                "Error while converting slice of size {} to `X25519PublicKey`: {}",
-                bytes.len(),
-                e,
-            ))
-        })?;
+        let bytes = <[u8; Self::LENGTH]>::try_from(bytes)
+            .map_err(|e| Self::Error::ConversionError(e.to_string()))?;
         Self::try_from(bytes)
     }
 }
@@ -250,6 +253,7 @@ impl From<X25519PublicKey> for [u8; X25519_PK_LENGTH] {
 impl TryFrom<&str> for X25519PublicKey {
     type Error = CryptoCoreError;
 
+    #[inline]
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         let bytes = hex::decode(value)?;
         Self::try_from(bytes.as_slice())
@@ -266,6 +270,7 @@ impl Display for X25519PublicKey {
 impl<'a> Sub<&'a X25519PublicKey> for &X25519PublicKey {
     type Output = X25519PublicKey;
 
+    #[inline]
     fn sub(self, rhs: &X25519PublicKey) -> Self::Output {
         X25519PublicKey(self.0 - rhs.0)
     }
@@ -274,6 +279,7 @@ impl<'a> Sub<&'a X25519PublicKey> for &X25519PublicKey {
 impl<'a> Add<&'a X25519PublicKey> for &X25519PublicKey {
     type Output = X25519PublicKey;
 
+    #[inline]
     fn add(self, rhs: &X25519PublicKey) -> Self::Output {
         X25519PublicKey(self.0 + rhs.0)
     }
@@ -282,12 +288,14 @@ impl<'a> Add<&'a X25519PublicKey> for &X25519PublicKey {
 impl<'a> Mul<&'a X25519PrivateKey> for &X25519PublicKey {
     type Output = X25519PublicKey;
 
+    #[inline]
     fn mul(self, rhs: &X25519PrivateKey) -> Self::Output {
         X25519PublicKey(self.0 * rhs.0)
     }
 }
 
 impl Zeroize for X25519PublicKey {
+    #[inline]
     fn zeroize(&mut self) {
         self.0.zeroize()
     }
@@ -295,6 +303,7 @@ impl Zeroize for X25519PublicKey {
 
 // Implements `Drop` trait to follow R23.
 impl Drop for X25519PublicKey {
+    #[inline]
     fn drop(&mut self) {
         self.zeroize();
     }
@@ -332,6 +341,7 @@ impl DhKeyPair<X25519_PK_LENGTH, X25519_SK_LENGTH> for X25519KeyPair {
 }
 
 impl Zeroize for X25519KeyPair {
+    #[inline]
     fn zeroize(&mut self) {
         self.pk.zeroize();
         self.sk.zeroize();
@@ -340,6 +350,7 @@ impl Zeroize for X25519KeyPair {
 
 // Implements `Drop` trait to follow R23.
 impl Drop for X25519KeyPair {
+    #[inline]
     fn drop(&mut self) {
         self.zeroize();
     }

--- a/src/asymmetric_crypto/mod.rs
+++ b/src/asymmetric_crypto/mod.rs
@@ -3,7 +3,7 @@ use core::{
     fmt::Debug,
     ops::{Add, Div, Mul, Sub},
 };
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRngCore;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 pub mod curve25519;
@@ -35,7 +35,7 @@ where
 
     /// Creates a new key pair
     #[must_use]
-    fn new<R: RngCore + CryptoRng>(rng: &mut R) -> Self;
+    fn new<R: CryptoRngCore>(rng: &mut R) -> Self;
 
     /// Returns a reference to the public key.
     fn public_key(&self) -> &Self::PublicKey;

--- a/src/kdf.rs
+++ b/src/kdf.rs
@@ -1,0 +1,52 @@
+/// Key Derivation Function (KDF).
+///
+/// Derives the given inputs to the desired length using SHAKE256, which should
+/// then be imported where this macro is used:
+///
+/// # Security
+///
+/// The byte inputs shall contain enough entropy. For inputs with lower entropy
+/// like passwords, the Argon2 algorithm should be used.
+///
+/// # Example
+///
+/// ```
+/// #[macro_use]
+/// use cosmian_crypto_core::kdf;
+///
+/// use sha3::{
+///     digest::{ExtendableOutput, Update, XofReader},
+///     Shake256,
+/// };
+///
+/// const KEY_LENGTH: usize = 32;
+///
+/// // input containing enough entropy
+/// const ikm: &str = "asdf34@!dsa@grq5e$2ASGy5";
+///
+/// // derive a 32-bytes key
+/// let key = kdf!(KEY_LENGTH, ikm.as_bytes());
+///
+/// assert_eq!(KEY_LENGTH, key.len());
+/// assert_eq!(key, kdf!(KEY_LENGTH, ikm.as_bytes()));
+/// ```
+///
+/// # Parameters
+///
+/// - `length`  : desired length (needs to be constant)
+/// - `bytes`   : KDF input
+#[macro_export]
+macro_rules! kdf {
+    ($length: ident, $($bytes: expr),+) => {
+        {
+            let mut hasher = Shake256::default();
+            $(
+                hasher.update($bytes);
+            )*
+            let mut reader = hasher.finalize_xof();
+            let mut res = [0; $length];
+            reader.read(&mut res);
+            res
+        }
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ mod error;
 
 pub mod asymmetric_crypto;
 pub mod entropy;
+pub mod kdf;
 pub mod symmetric_crypto;
 
 use rand_core::{CryptoRng, RngCore};

--- a/src/symmetric_crypto/key.rs
+++ b/src/symmetric_crypto/key.rs
@@ -1,8 +1,8 @@
-//! Define a symmetric key object of variable size.
+//! Defines a symmetric key object of variable size.
 
 use crate::{symmetric_crypto::SymKey, CryptoCoreError, KeyTrait};
 use core::{convert::TryFrom, fmt::Display, hash::Hash, ops::Deref};
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRngCore;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// Symmetric key of a given size.
@@ -14,7 +14,7 @@ pub struct Key<const LENGTH: usize>([u8; LENGTH]);
 impl<const LENGTH: usize> KeyTrait<LENGTH> for Key<LENGTH> {
     /// Generates a new symmetric random `Key`.
     #[inline]
-    fn new<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+    fn new<R: CryptoRngCore>(rng: &mut R) -> Self {
         let mut key = [0; LENGTH];
         rng.fill_bytes(&mut key);
         Self(key)
@@ -55,7 +55,7 @@ impl<const LENGTH: usize> SymKey<LENGTH> for Key<LENGTH> {
     }
 }
 
-impl<const KEY_LENGTH: usize> Display for Key<KEY_LENGTH> {
+impl<const LENGTH: usize> Display for Key<LENGTH> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", hex::encode(self.as_bytes()))
     }
@@ -76,9 +76,9 @@ impl<const LENGTH: usize> Drop for Key<LENGTH> {
     }
 }
 
-impl<const KEY_LENGTH: usize> ZeroizeOnDrop for Key<KEY_LENGTH> {}
+impl<const LENGTH: usize> ZeroizeOnDrop for Key<LENGTH> {}
 
-impl<const KEY_LENGTH: usize> Deref for Key<KEY_LENGTH> {
+impl<const LENGTH: usize> Deref for Key<LENGTH> {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {

--- a/src/symmetric_crypto/key.rs
+++ b/src/symmetric_crypto/key.rs
@@ -61,14 +61,16 @@ impl<const KEY_LENGTH: usize> Display for Key<KEY_LENGTH> {
     }
 }
 
-impl<const KEY_LENGTH: usize> Zeroize for Key<KEY_LENGTH> {
+impl<const LENGTH: usize> Zeroize for Key<LENGTH> {
+    #[inline]
     fn zeroize(&mut self) {
         self.0.zeroize();
     }
 }
 
 // Implements `Drop` trait to follow R23.
-impl<const KEY_LENGTH: usize> Drop for Key<KEY_LENGTH> {
+impl<const LENGTH: usize> Drop for Key<LENGTH> {
+    #[inline]
     fn drop(&mut self) {
         self.zeroize();
     }

--- a/src/symmetric_crypto/nonce.rs
+++ b/src/symmetric_crypto/nonce.rs
@@ -74,18 +74,21 @@ impl<const NONCE_LENGTH: usize> NonceTrait for Nonce<NONCE_LENGTH> {
 impl<'a, const NONCE_LENGTH: usize> TryFrom<&'a [u8]> for Nonce<NONCE_LENGTH> {
     type Error = CryptoCoreError;
 
+    #[inline]
     fn try_from(bytes: &'a [u8]) -> Result<Self, Self::Error> {
         Self::try_from_bytes(bytes)
     }
 }
 
-impl<const NONCE_LENGTH: usize> From<[u8; NONCE_LENGTH]> for Nonce<NONCE_LENGTH> {
-    fn from(b: [u8; NONCE_LENGTH]) -> Self {
+impl<const LENGTH: usize> From<[u8; LENGTH]> for Nonce<LENGTH> {
+    #[inline]
+    fn from(b: [u8; LENGTH]) -> Self {
         Self(b)
     }
 }
 
-impl<const NONCE_LENGTH: usize> Display for Nonce<NONCE_LENGTH> {
+impl<const LENGTH: usize> Display for Nonce<LENGTH> {
+    #[inline]
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", hex::encode(self.0))
     }

--- a/src/symmetric_crypto/nonce.rs
+++ b/src/symmetric_crypto/nonce.rs
@@ -5,10 +5,10 @@
 
 use crate::CryptoCoreError;
 use core::{
-    convert::{TryFrom, TryInto},
+    convert::TryFrom,
     fmt::{Debug, Display},
 };
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRngCore;
 
 /// Defines a nonce to use in a symmetric encryption scheme.
 pub trait NonceTrait: Send + Sync + Sized + Clone {
@@ -17,7 +17,7 @@ pub trait NonceTrait: Send + Sync + Sized + Clone {
 
     /// Generates a new nonce object.
     #[must_use]
-    fn new<R: RngCore + CryptoRng>(rng: &mut R) -> Self;
+    fn new<R: CryptoRngCore>(rng: &mut R) -> Self;
 
     /// Tries to deserialize the given `bytes` into a nonce object. The number
     /// of `bytes` must be equal to `Self::LENGTH`.
@@ -35,25 +35,23 @@ pub trait NonceTrait: Send + Sync + Sized + Clone {
 ///
 /// Internally, it uses an array of bytes of the given size.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Nonce<const NONCE_LENGTH: usize>([u8; NONCE_LENGTH]);
+pub struct Nonce<const LENGTH: usize>([u8; LENGTH]);
 
-impl<const NONCE_LENGTH: usize> NonceTrait for Nonce<NONCE_LENGTH> {
-    const LENGTH: usize = NONCE_LENGTH;
+impl<const LENGTH: usize> NonceTrait for Nonce<LENGTH> {
+    const LENGTH: usize = LENGTH;
 
     #[inline]
-    fn new<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
-        let mut bytes = [0; NONCE_LENGTH];
+    fn new<R: CryptoRngCore>(rng: &mut R) -> Self {
+        let mut bytes = [0; LENGTH];
         rng.fill_bytes(&mut bytes);
         Self(bytes)
     }
 
     #[inline]
     fn try_from_bytes(bytes: &[u8]) -> Result<Self, CryptoCoreError> {
-        let b: [u8; NONCE_LENGTH] = bytes.try_into().map_err(|_| CryptoCoreError::SizeError {
-            given: bytes.len(),
-            expected: NONCE_LENGTH,
-        })?;
-        Ok(Self(b))
+        let bytes = <[u8; LENGTH]>::try_from(bytes)
+            .map_err(|e| CryptoCoreError::ConversionError(e.to_string()))?;
+        Ok(Self(bytes))
     }
 
     #[inline]
@@ -71,7 +69,7 @@ impl<const NONCE_LENGTH: usize> NonceTrait for Nonce<NONCE_LENGTH> {
     }
 }
 
-impl<'a, const NONCE_LENGTH: usize> TryFrom<&'a [u8]> for Nonce<NONCE_LENGTH> {
+impl<'a, const LENGTH: usize> TryFrom<&'a [u8]> for Nonce<LENGTH> {
     type Error = CryptoCoreError;
 
     #[inline]


### PR DESCRIPTION
- add a KDF imlementation back because other crates may need it (we need it in Findex anyway). Use SHAKE256 in Xof mode. Use a macro `kdf!` since the number of parameters may vary (this way, we don't have to concatenate inputs) and this is not possible in Rust functions. I could have used a function with `input: &[&[u8]]` as parameters, but I think the macro keeps things simple.
- remove two unneeded libraries from `Cargo.toml`
- add missing `#[inline]` directives
- shorten constant generic names like `NONCE_LENGTH -> LENGTH` when it is not ambiguous
- use `CryptoRngCore` instead of `CryptoRng + RngCore` for random number generators