### PR TITLE
Features/use chacha12rng

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ All notable changes to this project will be documented in this file.
 ---
 ## [4.0.0] - 2022-10-18
 ### Added
+- `serialization` module
+- demo in `examples/demo.rs`
 ### Changed
 - replace `Hc128` by `ChaCha12Rng`
+- `README.md` follows template
 ### Fixed
 ### Removed
 - `Metadata`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ All notable changes to this project will be documented in this file.
 ## [4.0.0] - 2022-10-18
 ### Added
 ### Changed
+- replace `Hc128` by `ChaCha12Rng`
 ### Fixed
 ### Removed
 - `Metadata`
+- custom `CsRng` interface -> use `RngCore` or `SeedableRng` instead
 ---
 
 ---

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,7 @@ dependencies = [
  "curve25519-dalek",
  "getrandom 0.2.7",
  "hex",
+ "leb128",
  "rand_chacha",
  "serde",
  "sha3",
@@ -444,6 +445,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,15 +159,14 @@ dependencies = [
 
 [[package]]
 name = "cosmian_crypto_core"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "aes-gcm",
  "criterion",
  "curve25519-dalek",
  "getrandom 0.2.7",
  "hex",
- "rand_core 0.6.4",
- "rand_hc",
+ "rand_chacha",
  "serde",
  "sha3",
  "thiserror",
@@ -554,6 +553,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,6 +577,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,15 +602,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.7",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core 0.6.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,7 @@ curve25519-dalek = "3.2"
 # specify the js feature for the WASM target
 getrandom = { version = "0.2", features = ["js"] }
 hex = "0.4"
-rand_core = { version = "0.6", features = ["std", "getrandom"] }
-rand_hc = "0.3"
+rand_chacha = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 zeroize = "1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ curve25519-dalek = "3.2"
 # specify the js feature for the WASM target
 getrandom = { version = "0.2", features = ["js"] }
 hex = "0.4"
+leb128 = "0.2.5"
 rand_chacha = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cosmian_crypto_core &emsp; [![Build Status]][actions] [![Latest Version]][crates.io]
+# Cosmian CryptoCore &emsp; [![Build Status]][actions] [![Latest Version]][crates.io]
 
 
 [Build Status]: https://img.shields.io/github/workflow/status/Cosmian/crypto_core/CI%20checks/main
@@ -6,42 +6,179 @@
 [Latest Version]: https://img.shields.io/crates/v/cosmian_crypto_core.svg
 [crates.io]: https://crates.io/crates/cosmian_crypto_core
 
-This crate implements crypto primitives which are used in many other
-Cosmian cryptographic resources:
+This crate implements the cryptographic primitives which are used in many other
+Cosmian resources:
 
-- symmetric cryptography primitives can be found in the `symmetric_crypto` module;
-- asymmetric cryptography primitives can be found in the `asymmetric_crypto` module;
-- a Random Number Generator (RNG) can be found in the `entropy` module.
+- a Data Encryption Method (DEM) based on AES256-GCM (128 bytes of security)
+  offering a simple API (Nonce management and authentication checks are internals);
+- a Diffie-Hellman key pair based on the curve25519 (128 bytes of security)
+  allowing implementation of Diffie-Hellman based asymmetric cryptography;
+- a Random Number Generator (RNG) implementing the ChaCha algorithm with 12
+  rounds (128 bytes of security).
+- a Key Derivation Function (KDF) based on SHAKE128 (128 bytes of security);
 
-The crate also defines `CryptoCoreError`, the error type, and a few traits.
+All these primitives are use pure rust implementations, are secure, and used
+the fastest known algorithms. They offer a great basis on which to build more
+complex softwares.
 
-## Symmetric Crypto
+## Getting started
 
-This crate implements a Data Encapsulation Mechanism (DEM) based on the AES 256
-GCM algorithm, as described in the [ISO 2004](https://www.shoup.net/iso/std6.pdf).
-This implementation is 128-bits secure.
+The following example can be run using `cargo run --example demo`.
 
-It uses the [`aes_gcm`](https://docs.rs/aes-gcm/latest/aes_gcm/index.html)
-implementation of the AES GCM algorithm. This implementation makes use of the
-AES instruction set when available, which allows for a high encryption speed.
+```rust
+use cosmian_crypto_core::{
+    asymmetric_crypto::{curve25519::X25519KeyPair, DhKeyPair},
+    kdf,
+    reexport::rand_core::SeedableRng,
+    symmetric_crypto::{aes_256_gcm_pure::Aes256GcmCrypto, Dem, SymKey},
+    CsRng, KeyTrait,
+};
+use sha3::{
+    digest::XofReader,
+    digest::{ExtendableOutput, Update},
+    Shake128,
+};
 
-## Asymmetric Crypto
+// The random generator should be instantiated at the highest possible
+// level since its creation is relatively costly.
+let mut rng = CsRng::from_entropy();
 
-This crate implements a public and a private key objects based on Curve25519.
-This one of the fastest elliptic curves known when implementing these objects.
-Its security level is also 128 bits.
+// Secret message we want to transmit privately.
+let plaintext = b"My secret message";
+
+// Publicly known information. It can be used to enforce context separation.
+let additional_data = Some(b"Some public tag".as_slice());
+
+// Setting of the asymmetric keys
+let bob_keypair = X25519KeyPair::new(&mut rng);
+let alice_keypair = X25519KeyPair::new(&mut rng);
+
+// In real world applications, DHKEX is often used to derive a symmetric key.
+let shared_secret = bob_keypair.public_key() * alice_keypair.private_key();
+
+// Derivation of a secret key from the DHKEX shared secret.
+const KEY_DERIVATION_INFO: &[u8] = b"Curve25519 KDF derivation";
+const KEY_LENGTH: usize = Aes256GcmCrypto::KEY_LENGTH;
+let symmetric_key = SymKey::<KEY_LENGTH>::from_bytes(kdf!(
+    KEY_LENGTH,
+    &shared_secret.to_bytes(),
+    KEY_DERIVATION_INFO
+));
+
+// DEM encapsulation using AES256-GCM. In order to prevent nonce reuse,
+// the nonce is managed internally.
+let c = Aes256GcmCrypto::encrypt(&mut rng, &symmetric_key, plaintext, additional_data).unwrap();
+
+// DEM decryption using AES256-GCM. The additional data used should be the
+// same as the one given for encryption.
+let res = Aes256GcmCrypto::decrypt(&symmetric_key, &c, additional_data).unwrap();
+
+assert_eq!(res, plaintext, "Decryption failed!");
+
+println!("Message has been privately and successfully transmitted!");
+```
+
+## Building and Testing
+
+### Build
+
+To install and build Cosmian CryptoCore, just clone the repo:
+```
+git clone https://github.com/Cosmian/crypto_core.git
+```
+and build it with Cargo:
+```
+cargo build --release
+```
+
+### Use
+
+To use Cosmian CryptoCore in another Rust software, just add the dependency
+using Cargo:
+```
+cargo add cosmian_crypto_core
+```
+and use it in your project!
+
+### Run tests and benchmarks
+
+Tests can be run with:
+```
+cargo test --release
+```
+
+Benchmarks can be run with:
+```
+cargo bench
+```
+
+## Features and Benchmarks
+
+The benchmarks given below are run on a Intel(R) Core(TM) i7-10750H CPU @ 3.20GHz.
+
+### Asymmetric Crypto
+
+This crate implements a Diffie-Hellman asymmetric key pair based on the
+Curve25519. This is one of the fastest elliptic curves known at this time and
+it offers 128 bits of security.
 
 It uses the [Dalek](https://github.com/dalek-cryptography/curve25519-dalek)
 implementation, which offers an implementation of the Ristretto technique to
 construct a prime order group on the curve. This group is used to implement
 the public key.
 
-## Random Number Generator (RNG)
+```
+Bench the Group-Scalar multiplication on which is based the Diffie-Helman key exchange
+                        time:   [59.932 µs 60.131 µs 60.364 µs]
+```
+
+### Symmetric Crypto
+
+This crate implements a Data Encryption Method (DEM) based on the AES256-GCM
+algorithm, as described in the [ISO 2004](https://www.shoup.net/iso/std6.pdf).
+This implementation is 128-bits secure in both the classic and the post-quantum
+models.
+
+It uses the [`aes_gcm`](https://docs.rs/aes-gcm/latest/aes_gcm/index.html)
+implementation of the AES GCM algorithm. This implementation makes use of the
+AES instruction set when available, which allows for a high encryption speed.
+
+```
+Bench the DEM encryption of a 2048-bytes message without additional data
+                        time:   [2.7910 µs 2.7911 µs 2.7914 µs]
+
+Bench the DEM decryption of a 2048-bytes message without additional data
+                        time:   [2.7074 µs 2.7079 µs 2.7085 µs]
+```
+
+### Random Number Generator (RNG)
 
 This crate uses the implementation of the CHACHA algorithm with 12 rounds from
 the [`rand_chacha`](https://rust-random.github.io/rand/rand_chacha/index.html)
 crate to construct our RNG. It is therefore 128-bits secure.
 
-## Building
+```
+Bench the generation of a cryptographic RNG
+                        time:   [1.2355 µs 1.2368 µs 1.2382 µs]
+```
 
-The default feature schemes can all be built to a WASM target.
+### Key Derivation Function (KDF)
+
+This crate uses the pure rust implementation of the SHAKE128 algorithm from the
+[sha3](https://docs.rs/sha3/latest/sha3) crate. This allows implementing a KDF
+which 128-bits secure for input sizes of at least 256 bits (32 bytes).
+
+```
+bench the KDF derivation of a 32-bytes IKM into a 64-bytes key
+                        time:   [1.1065 µs 1.1067 µs 1.1070 µs]
+```
+
+## Documentation
+
+The documentation can be generated using Cargo:
+```
+cargo docs
+```
+
+It is also available on
+[doc.rs](https://docs.rs/cosmian_crypto_core/latest/cosmian_crypto_core/).

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ the public key.
 
 ## Random Number Generator (RNG)
 
-This crate uses the implementation of the HC128 algorithm from the
-[Rust standard library](https://docs.rs/rand/0.5.0/rand/prng/hc128/struct.Hc128Rng.html)
-to construct our RNG. It is therefore 128-bits secure.
+This crate uses the implementation of the CHACHA algorithm with 12 rounds from
+the [`rand_chacha`](https://rust-random.github.io/rand/rand_chacha/index.html)
+crate to construct our RNG. It is therefore 128-bits secure.
 
 ## Building
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,0 +1,54 @@
+//! This demo is used in `README.md`.
+
+use cosmian_crypto_core::{
+    asymmetric_crypto::{curve25519::X25519KeyPair, DhKeyPair},
+    kdf,
+    reexport::rand_core::SeedableRng,
+    symmetric_crypto::{aes_256_gcm_pure::Aes256GcmCrypto, Dem, SymKey},
+    CsRng, KeyTrait,
+};
+use sha3::{
+    digest::XofReader,
+    digest::{ExtendableOutput, Update},
+    Shake128,
+};
+
+fn main() {
+    // The random generator should be instantiated at the highest possible
+    // level since its creation is relatively costly.
+    let mut rng = CsRng::from_entropy();
+
+    // Secret message we want to transmit privately.
+    let plaintext = b"My secret message";
+
+    // Publicly known information. It can be used to enforce context separation.
+    let additional_data = Some(b"Some public tag".as_slice());
+
+    // Setting of the asymmetric keys
+    let bob_keypair = X25519KeyPair::new(&mut rng);
+    let alice_keypair = X25519KeyPair::new(&mut rng);
+
+    // In real world applications, DHKEX is often used to derive a symmetric key.
+    let shared_secret = bob_keypair.public_key() * alice_keypair.private_key();
+
+    // Derivation of a secret key from the DHKEX shared secret.
+    const KEY_DERIVATION_INFO: &[u8] = b"Curve25519 KDF derivation";
+    const KEY_LENGTH: usize = Aes256GcmCrypto::KEY_LENGTH;
+    let symmetric_key = SymKey::<KEY_LENGTH>::from_bytes(kdf!(
+        KEY_LENGTH,
+        &shared_secret.to_bytes(),
+        KEY_DERIVATION_INFO
+    ));
+
+    // DEM encapsulation using AES256-GCM. In order to prevent nonce reuse,
+    // the nonce is managed internally.
+    let c = Aes256GcmCrypto::encrypt(&mut rng, &symmetric_key, plaintext, additional_data).unwrap();
+
+    // DEM decryption using AES256-GCM. The additional data used should be the
+    // same as the one given for encryption.
+    let res = Aes256GcmCrypto::decrypt(&symmetric_key, &c, additional_data).unwrap();
+
+    assert_eq!(res, plaintext, "Decryption failed!");
+
+    println!("Message has been privately and successfully transmitted!");
+}

--- a/src/asymmetric_crypto/curve25519.rs
+++ b/src/asymmetric_crypto/curve25519.rs
@@ -5,7 +5,9 @@
 //! Its security level is 128-bits. It is the fastest curve available at the
 //! time of this implementation.
 
-use crate::{asymmetric_crypto::DhKeyPair, CryptoCoreError, KeyTrait};
+use crate::{
+    asymmetric_crypto::DhKeyPair, reexport::rand_core::CryptoRngCore, CryptoCoreError, KeyTrait,
+};
 use core::{
     convert::TryFrom,
     fmt::Display,
@@ -16,7 +18,6 @@ use curve25519_dalek::{
     ristretto::{CompressedRistretto, RistrettoPoint},
     scalar::Scalar,
 };
-use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
@@ -360,11 +361,13 @@ impl ZeroizeOnDrop for X25519KeyPair {}
 
 #[cfg(test)]
 mod test {
-    use crate::{asymmetric_crypto::curve25519::*, entropy::CsRng, KeyTrait};
+    use crate::{
+        asymmetric_crypto::curve25519::*, reexport::rand_core::SeedableRng, CsRng, KeyTrait,
+    };
 
     #[test]
     fn test_private_key_serialization() {
-        let mut rng = CsRng::new();
+        let mut rng = CsRng::from_entropy();
         let sk = X25519PrivateKey::new(&mut rng);
         let bytes: [u8; X25519_PRIVATE_KEY_LENGTH] = sk.to_bytes();
         let recovered = X25519PrivateKey::try_from(bytes).unwrap();
@@ -373,7 +376,7 @@ mod test {
 
     #[test]
     fn test_public_key_serialization() {
-        let mut rng = CsRng::new();
+        let mut rng = CsRng::from_entropy();
         let pk = X25519PublicKey::new(&mut rng);
         let bytes: [u8; X25519_PUBLIC_KEY_LENGTH] = pk.to_bytes();
         let recovered = super::X25519PublicKey::try_from(bytes).unwrap();
@@ -382,7 +385,7 @@ mod test {
 
     #[test]
     fn test_dh_key_pair() {
-        let mut rng = CsRng::new();
+        let mut rng = CsRng::from_entropy();
         let kp1 = X25519KeyPair::new(&mut rng);
         let kp2 = X25519KeyPair::new(&mut rng);
         // check the keys are randomly generated

--- a/src/asymmetric_crypto/mod.rs
+++ b/src/asymmetric_crypto/mod.rs
@@ -1,9 +1,8 @@
-use crate::KeyTrait;
+use crate::{reexport::rand_core::CryptoRngCore, KeyTrait};
 use core::{
     fmt::Debug,
     ops::{Add, Div, Mul, Sub},
 };
-use rand_core::CryptoRngCore;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 pub mod curve25519;

--- a/src/bytes_ser_de.rs
+++ b/src/bytes_ser_de.rs
@@ -1,0 +1,200 @@
+//! Implement the `Serializer` and `Deserializer` objects using LEB128.
+
+use crate::CryptoCoreError;
+use leb128;
+use std::io::{Read, Write};
+
+/// A `Serializable` object can easily be serialized and derserialized into an
+/// array of bytes.
+pub trait Serializable: Sized {
+    /// Writes to the given `Serializer`.
+    fn write(&self, ser: &mut Serializer) -> Result<usize, CryptoCoreError>;
+
+    /// Reads from the given `Deserializer`.
+    fn read(de: &mut Deserializer) -> Result<Self, CryptoCoreError>;
+
+    /// Serializes the object.
+    #[inline]
+    fn try_to_bytes(&self) -> Result<Vec<u8>, CryptoCoreError> {
+        let mut ser = Serializer::new();
+        self.write(&mut ser)?;
+        Ok(ser.finalize())
+    }
+
+    /// Deserializes the object.
+    #[inline]
+    fn try_from_bytes(bytes: &[u8]) -> Result<Self, CryptoCoreError> {
+        if bytes.is_empty() {
+            return Err(CryptoCoreError::InvalidSize(
+                "Given byte string is empty".to_string(),
+            ));
+        }
+        let mut de = Deserializer::new(bytes);
+        Self::read(&mut de)
+    }
+}
+
+pub struct Deserializer<'a> {
+    readable: &'a [u8],
+}
+
+impl<'a> Deserializer<'a> {
+    /// Generates a new `Deserializer` from the given bytes.
+    ///
+    /// - `bytes`   : bytes to deserialize
+    #[inline]
+    pub const fn new(bytes: &'a [u8]) -> Deserializer<'a> {
+        Deserializer { readable: bytes }
+    }
+
+    /// Reads a `u64` from the `Deserializer`.
+    #[inline]
+    pub fn read_u64(&mut self) -> Result<u64, CryptoCoreError> {
+        leb128::read::unsigned(&mut self.readable).map_err(|e| {
+            CryptoCoreError::InvalidSize(format!(
+                "Deserializer: failed reading the size of the next array: {}",
+                e
+            ))
+        })
+    }
+
+    /// Reads an array of bytes of length `LENGTH` from the `Deserializer`.
+    #[inline]
+    pub fn read_array<const LENGTH: usize>(&mut self) -> Result<[u8; LENGTH], CryptoCoreError> {
+        let mut buf = [0; LENGTH];
+        self.readable.read_exact(&mut buf).map_err(|_| {
+            CryptoCoreError::InvalidSize(format!(
+                "Deserializer: failed reading array of: {LENGTH} bytes",
+            ))
+        })?;
+        Ok(buf)
+    }
+
+    /// Reads a vector of bytes from the `Deserializer`.
+    ///
+    /// Vectors serialization overhead is `size_of(LEB128(vector_size))`, where
+    /// `LEB128()` is the LEB128 serialization function.
+    pub fn read_vec(&mut self) -> Result<Vec<u8>, CryptoCoreError> {
+        // The size of the vector is prefixed to the serialization.
+        let len_u64 = self.read_u64()?;
+        if len_u64 == 0 {
+            return Ok(vec![]);
+        };
+        let len = usize::try_from(len_u64).map_err(|_| {
+            CryptoCoreError::InvalidSize(format!(
+                "Deserializer: size of array is too big: {} bytes",
+                len_u64
+            ))
+        })?;
+        let mut buf = vec![0_u8; len];
+        self.readable.read_exact(&mut buf).map_err(|_| {
+            CryptoCoreError::InvalidSize(format!(
+                "Deserializer: failed reading array of: {} bytes",
+                len
+            ))
+        })?;
+        Ok(buf)
+    }
+
+    /// Consumes the `Deserializer` and returns the remaining bytes.
+    #[inline]
+    pub fn finalize(self) -> Vec<u8> {
+        self.readable.to_vec()
+    }
+}
+
+pub struct Serializer {
+    writable: Vec<u8>,
+}
+
+impl Serializer {
+    /// Generates a new `Serializer`.
+    #[inline]
+    pub const fn new() -> Self {
+        Self { writable: vec![] }
+    }
+
+    /// Writes a `u64` to the `Serializer`.
+    ///
+    /// - `n`   : `u64` to write
+    #[inline]
+    pub fn write_u64(&mut self, n: u64) -> Result<usize, CryptoCoreError> {
+        leb128::write::unsigned(&mut self.writable, n).map_err(|e| {
+            CryptoCoreError::InvalidSize(format!(
+                "Serializer: unexpected LEB128 error writing {} bytes: {}",
+                n, e
+            ))
+        })
+    }
+
+    /// Writes an array of bytes to the `Serializer`.
+    ///
+    /// - `array`   : array of bytes to write
+    #[inline]
+    pub fn write_array(&mut self, array: &[u8]) -> Result<usize, CryptoCoreError> {
+        self.writable.write(array).map_err(|e| {
+            CryptoCoreError::InvalidSize(format!(
+                "Serializer: unexpected error writing {} bytes: {}",
+                array.len(),
+                e
+            ))
+        })
+    }
+
+    /// Writes a vector of bytes to the `Serializer`.
+    ///
+    /// Vectors serialization overhead is `size_of(LEB128(vector_size))`, where
+    /// `LEB128()` is the LEB128 serialization function.
+    ///
+    /// - `vector`  : vector of bytes to write
+    #[inline]
+    pub fn write_vec(&mut self, vector: &[u8]) -> Result<usize, CryptoCoreError> {
+        // Use the size as prefix. This allows inializing the vector with the
+        // correct capacity on deserialization.
+        let mut len = self.write_u64(vector.len() as u64)?;
+        len += self.write_array(vector)?;
+        Ok(len)
+    }
+
+    /// Consumes the `Serializer` and returns the serialized bytes.
+    #[inline]
+    pub fn finalize(self) -> Vec<u8> {
+        self.writable
+    }
+}
+
+impl Default for Serializer {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Deserializer, Serializer};
+    use crate::CryptoCoreError;
+
+    #[test]
+    pub fn test_ser_de() -> Result<(), CryptoCoreError> {
+        let a1 = b"azerty".to_vec();
+        let a2 = b"".to_vec();
+        let a3 = "nbvcxwmlkjhgfdsqpoiuytreza)àç_è-('é&".as_bytes().to_vec();
+
+        let mut ser = Serializer::new();
+        assert_eq!(7, ser.write_vec(&a1)?);
+        assert_eq!(1, ser.write_vec(&a2)?);
+        assert_eq!(41, ser.write_vec(&a3)?);
+        assert_eq!(49, ser.writable.len());
+
+        let mut de = Deserializer::new(&ser.writable);
+        let a1_ = de.read_vec()?;
+        assert_eq!(a1, a1_);
+        let a2_ = de.read_vec()?;
+        assert_eq!(a2, a2_);
+        let a3_ = de.read_vec()?;
+        assert_eq!(a3, a3_);
+
+        Ok(())
+    }
+}

--- a/src/entropy.rs
+++ b/src/entropy.rs
@@ -1,11 +1,11 @@
-use rand_core::{CryptoRng, RngCore, SeedableRng};
-use rand_hc::Hc128Rng;
+use crate::reexport::rand_core::{CryptoRng, Error, RngCore, SeedableRng};
+use rand_chacha::ChaCha12Rng;
 
 /// An implementation of a cryptographically secure
-/// pseudo random generator using HC128
+/// pseudo random generator using ThreadRng.
 #[derive(Debug)]
 pub struct CsRng {
-    rng: Hc128Rng,
+    rng: ChaCha12Rng,
 }
 
 impl CsRng {
@@ -14,7 +14,7 @@ impl CsRng {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            rng: Hc128Rng::from_entropy(),
+            rng: ChaCha12Rng::from_entropy(),
         }
     }
 
@@ -53,8 +53,8 @@ impl RngCore for CsRng {
     }
 
     #[inline]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.rng.try_fill_bytes(dest).map_err(rand_core::Error::new)
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+        self.rng.try_fill_bytes(dest)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,26 +1,17 @@
 //! This crate implements crypto primitives which are used in many other
-//! Cosmian cryptographic resources:
-//!
-//! - symmetric cryptography primitives can be found in the `symmetric_crypto` module;
-//! - asymmetric cryptography primitives can be found in the `asymmetric_crypto` module;
-//! - a Key Derivation Function (KDF) can be found in the `kdf` module;
-//! - a Random Number Generator (RNG) can be found in the `entropy` module.
-//!
-//! `CryptoCoreError` is the error type of the library.
-//!
-//! This crate also exposes a few traits for cryptographic objects defined in
-//! the modules.
+//! Cosmian cryptographic resources.
 
 mod error;
 
 pub mod asymmetric_crypto;
+pub mod bytes_ser_de;
 pub mod kdf;
-pub mod symmetric_crypto;
 pub mod reexport {
     // reexport `rand_core` so that the PRNGs implement the correct version of
     // the traits
     pub use rand_chacha::rand_core;
 }
+pub mod symmetric_crypto;
 
 use reexport::rand_core::{CryptoRng, RngCore};
 use zeroize::{Zeroize, ZeroizeOnDrop};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,20 +14,21 @@
 mod error;
 
 pub mod asymmetric_crypto;
-pub mod entropy;
 pub mod kdf;
 pub mod symmetric_crypto;
+pub mod reexport {
+    // reexport `rand_core` so that the PRNGs implement the correct version of
+    // the traits
+    pub use rand_chacha::rand_core;
+}
 
-use rand_core::{CryptoRng, RngCore};
+use reexport::rand_core::{CryptoRng, RngCore};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 pub use crate::error::CryptoCoreError;
 
-pub mod reexport {
-    // reexport `rand_core` so that the PRNGs implement the correct version of
-    // the traits
-    pub use rand_core;
-}
+/// Use ChaCha with 12 rounds as cryptographic RNG.
+pub type CsRng = rand_chacha::ChaCha12Rng;
 
 /// Cryptographic key.
 pub trait KeyTrait<const LENGTH: usize>:

--- a/src/symmetric_crypto/aes_256_gcm_pure/mod.rs
+++ b/src/symmetric_crypto/aes_256_gcm_pure/mod.rs
@@ -3,7 +3,8 @@
 //!
 //! It will use the AES native interface on the CPU if available.
 use crate::{
-    symmetric_crypto::{nonce::NonceTrait, Dem, SymKey},
+    reexport::rand_core::CryptoRngCore,
+    symmetric_crypto::{key::Key, nonce::Nonce, nonce::NonceTrait, Dem, SymKey},
     CryptoCoreError,
 };
 use aes_gcm::{
@@ -11,9 +12,6 @@ use aes_gcm::{
     aes::cipher::generic_array::GenericArray,
     AeadInPlace, Aes256Gcm, KeyInit,
 };
-use rand_core::{CryptoRng, RngCore};
-
-use super::{key::Key, nonce::Nonce};
 
 /// Use a 256-bit AES key.
 const KEY_LENGTH: usize = 32;
@@ -42,7 +40,7 @@ impl Dem<KEY_LENGTH> for Aes256GcmCrypto {
 
     type Nonce = Nonce<NONCE_LENGTH>;
 
-    fn encrypt<R: RngCore + CryptoRng>(
+    fn encrypt<R: CryptoRngCore>(
         rng: &mut R,
         secret_key: &Self::Key,
         plaintext: &[u8],
@@ -182,7 +180,7 @@ pub fn decrypt_in_place_detached(
 mod tests {
 
     use crate::{
-        entropy::CsRng,
+        reexport::rand_core::{RngCore, SeedableRng},
         symmetric_crypto::{
             aes_256_gcm_pure::{
                 decrypt_combined, decrypt_in_place_detached, encrypt_combined,
@@ -193,14 +191,15 @@ mod tests {
             nonce::NonceTrait,
             Dem, SymKey,
         },
-        CryptoCoreError, KeyTrait,
+        CryptoCoreError, CsRng, KeyTrait,
     };
 
     #[test]
     fn test_encryption_decryption_combined() -> Result<(), CryptoCoreError> {
-        let mut cs_rng = CsRng::new();
+        let mut cs_rng = CsRng::from_entropy();
         let key = Key::<KEY_LENGTH>::new(&mut cs_rng);
-        let bytes = cs_rng.generate_random_bytes::<8192>();
+        let mut bytes = [0; 8192];
+        cs_rng.fill_bytes(&mut bytes);
         let iv = Nonce::<NONCE_LENGTH>::new(&mut cs_rng);
         // no additional data
         let encrypted_result = encrypt_combined(&key, &bytes, iv.as_bytes(), None)?;
@@ -209,14 +208,16 @@ mod tests {
         let recovered = decrypt_combined(&key, &encrypted_result, iv.as_bytes(), None)?;
         assert_eq!(bytes.to_vec(), recovered);
         // additional data
-        let aad = cs_rng.generate_random_bytes::<42>();
+        let mut aad = [0; 42];
+        cs_rng.fill_bytes(&mut aad);
         let encrypted_result = encrypt_combined(&key, &bytes, iv.as_bytes(), Some(&aad))?;
         assert_ne!(encrypted_result, bytes.to_vec());
         assert_eq!(bytes.len() + MAC_LENGTH, encrypted_result.len());
         let recovered = decrypt_combined(&key, &encrypted_result, iv.as_bytes(), Some(&aad))?;
         assert_eq!(bytes.to_vec(), recovered);
         // data should not be recovered if the AAD is modified
-        let aad = cs_rng.generate_random_bytes::<42>();
+        let mut aad = [0; 42];
+        cs_rng.fill_bytes(&mut aad);
         let recovered = decrypt_combined(&key, &encrypted_result, iv.as_bytes(), Some(&aad));
         assert_ne!(Ok(bytes.to_vec()), recovered);
         // data should not be recovered if the key is modified
@@ -228,9 +229,10 @@ mod tests {
 
     #[test]
     fn test_encryption_decryption_detached() -> Result<(), CryptoCoreError> {
-        let mut cs_rng = CsRng::new();
+        let mut cs_rng = CsRng::from_entropy();
         let key = Key::<KEY_LENGTH>::new(&mut cs_rng);
-        let bytes = cs_rng.generate_random_bytes::<1024>();
+        let mut bytes = [0; 1024];
+        cs_rng.fill_bytes(&mut bytes);
         let iv = Nonce::<NONCE_LENGTH>::new(&mut cs_rng);
         // no additional data
         let mut data = bytes;
@@ -241,7 +243,8 @@ mod tests {
         decrypt_in_place_detached(&key, &mut data, &tag, iv.as_bytes(), None)?;
         assert_eq!(bytes, data);
         // // additional data
-        let ad = cs_rng.generate_random_bytes::<42>();
+        let mut ad = [0; 42];
+        cs_rng.fill_bytes(&mut ad);
         let mut data = bytes;
         let tag = encrypt_in_place_detached(&key, &mut data, iv.as_bytes(), Some(&ad))?;
         assert_ne!(bytes, data);
@@ -256,7 +259,7 @@ mod tests {
     fn test_dem() -> Result<(), CryptoCoreError> {
         let m = b"my secret message";
         let additional_data = Some(b"public tag".as_slice());
-        let mut rng = CsRng::new();
+        let mut rng = CsRng::from_entropy();
         let secret_key = Key::new(&mut rng);
         let c = Aes256GcmCrypto::encrypt(&mut rng, &secret_key, m, additional_data)?;
         let res = Aes256GcmCrypto::decrypt(&secret_key, &c, additional_data)?;

--- a/src/symmetric_crypto/key.rs
+++ b/src/symmetric_crypto/key.rs
@@ -1,8 +1,9 @@
 //! Defines a symmetric key object of variable size.
 
-use crate::{symmetric_crypto::SymKey, CryptoCoreError, KeyTrait};
+use crate::{
+    reexport::rand_core::CryptoRngCore, symmetric_crypto::SymKey, CryptoCoreError, KeyTrait,
+};
 use core::{convert::TryFrom, fmt::Display, hash::Hash, ops::Deref};
-use rand_core::CryptoRngCore;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// Symmetric key of a given size.
@@ -89,13 +90,13 @@ impl<const LENGTH: usize> Deref for Key<LENGTH> {
 #[cfg(test)]
 mod tests {
 
-    use crate::{entropy::CsRng, symmetric_crypto::key::Key, KeyTrait};
+    use crate::{reexport::rand_core::SeedableRng, symmetric_crypto::key::Key, CsRng, KeyTrait};
 
     const KEY_LENGTH: usize = 32;
 
     #[test]
     fn test_key() {
-        let mut cs_rng = CsRng::new();
+        let mut cs_rng = CsRng::from_entropy();
         let key_1 = Key::<KEY_LENGTH>::new(&mut cs_rng);
         assert_eq!(KEY_LENGTH, key_1.len());
         let key_2 = Key::new(&mut cs_rng);

--- a/src/symmetric_crypto/mod.rs
+++ b/src/symmetric_crypto/mod.rs
@@ -1,5 +1,5 @@
-//! Define the `SymmetricCrypto` and `DEM` traits and provide an implementation
-//! based on the AES GCM algorithm.
+//! Defines the `SymmetricCrypto` and `DEM` traits and provides an
+//! implementation based on AES256-GCM.
 
 pub mod aes_256_gcm_pure;
 pub mod key;

--- a/src/symmetric_crypto/mod.rs
+++ b/src/symmetric_crypto/mod.rs
@@ -5,10 +5,9 @@ pub mod aes_256_gcm_pure;
 pub mod key;
 pub mod nonce;
 
-use crate::{CryptoCoreError, KeyTrait};
+use crate::{reexport::rand_core::CryptoRngCore, CryptoCoreError, KeyTrait};
 use core::{fmt::Debug, hash::Hash};
 use nonce::NonceTrait;
-use rand_core::{CryptoRng, RngCore};
 use std::vec::Vec;
 
 /// Defines a symmetric encryption key.
@@ -51,7 +50,7 @@ pub trait Dem<const KEY_LENGTH: usize>: Debug + PartialEq {
     /// - `plaintext`   : plaintext message
     /// - `aad`         : optional data to use in the authentication method,
     /// must use the same for decryption
-    fn encrypt<R: RngCore + CryptoRng>(
+    fn encrypt<R: CryptoRngCore>(
         rng: &mut R,
         secret_key: &Self::Key,
         plaintext: &[u8],

--- a/src/symmetric_crypto/nonce.rs
+++ b/src/symmetric_crypto/nonce.rs
@@ -3,12 +3,11 @@
 //! A nonce, for Number used ONCE, is a randomly generated number used to
 //! ensure a ciphertext cannot be reused, hence avoiding replay attacks.
 
-use crate::CryptoCoreError;
+use crate::{reexport::rand_core::CryptoRngCore, CryptoCoreError};
 use core::{
     convert::TryFrom,
     fmt::{Debug, Display},
 };
-use rand_core::CryptoRngCore;
 
 /// Defines a nonce to use in a symmetric encryption scheme.
 pub trait NonceTrait: Send + Sync + Sized + Clone {
@@ -95,15 +94,16 @@ impl<const LENGTH: usize> Display for Nonce<LENGTH> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        entropy::CsRng,
+        reexport::rand_core::SeedableRng,
         symmetric_crypto::nonce::{Nonce, NonceTrait},
+        CsRng,
     };
 
     const NONCE_LENGTH: usize = 12;
 
     #[test]
     fn test_nonce() {
-        let mut cs_rng = CsRng::new();
+        let mut cs_rng = CsRng::from_entropy();
         let nonce_1 = Nonce::<NONCE_LENGTH>::new(&mut cs_rng);
         assert_eq!(NONCE_LENGTH, nonce_1.as_bytes().len());
         let nonce_2 = Nonce::<NONCE_LENGTH>::new(&mut cs_rng);


### PR DESCRIPTION
Use ChaCha with 12 rounds instead of Hc128, since this is really really fast (~ -80%) and secure !

**BREAKING CHANGE**: remove the `CsRng` custom interface, the way to
instantiate the new `CsRng` is to use `SeedableRng::from_entropy()`, the
way to generate bytes is to use `RngCore::fill_bytes()`.

**Note**: No version bump, this will be added to the major release v4.0 from #17 