### PR TITLE
Try fix ios build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 
 ---
+## [4.0.1] - 2022-10-24
+### Removed
+- crate-type `cdylib` in order to help the ios build
+---
+
+---
 ## [4.0.0] - 2022-10-19
 ### Added
 - benches

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "cosmian_crypto_core"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "aes-gcm",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,10 @@ description = "Crypto lib for pure crypto primitives"
 edition = "2021"
 license = "MIT/Apache-2.0"
 name = "cosmian_crypto_core"
-version = "4.0.0"
+version = "4.0.1"
 
 [lib]
-crate-type = ["cdylib", "rlib", "staticlib"]
+crate-type = ["rlib", "staticlib"]
 name = "cosmian_crypto_core"
 path = "src/lib.rs"
 


### PR DESCRIPTION
Try fix ios build (removing cdylib).

When cdylib is present, following error occurs later on (on projects depending on crypto_core):

```
error: failed to get iphoneos SDK path: process exit with error: osxcross: error: xcrun: '-sdk': expected macOS SDK

error: could not compile `cosmian_findex` due to previous error
[ERROR cargo_lipo] Failed to build "cosmian_findex" for "aarch64-apple-ios": Executing "/root/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/bin/cargo" "--color" "auto" "build" "-p" "cosmian_findex" "--target" "aarch64-apple-ios" "--release" "--lib" finished with error status: exit status: 101
root@299beefab449:~/project# cargo clean && cargo lipo --release --allow-run-on-non-macos
```