### PR TITLE
feat!: allow serializing with capacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ---
-## [4.1.0] - 2022-10-25
+## Unreleased
 ### Added
 - `<impl Serializable>::length()`
 - `Serializer::with_capacity()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,22 @@
 All notable changes to this project will be documented in this file.
 
 ---
+## [4.1.0] - 2022-10-25
+### Added
+- `<impl Serializable>::length()`
+- `Serializer::with_capacity()`
+### Changed
+- `<impl Serializable>::try_to_bytes()` now allocates
+  `<impl Serializable>::length()` bytes to the `Serializer` on creation
+### Fixed
+### Removed
+---
+
+---
 ## [4.0.1] - 2022-10-24
+### Added
+### Changed
+### Fixed
 ### Removed
 - crate-type `cdylib` in order to help the ios build
 ---

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe0133578c0986e1fe3dfcd4af1cc5b2dd6c3dbf534d69916ce16a2701d40ba"
+checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "cosmian_crypto_core"
-version = "4.1.0"
+version = "4.0.1"
 dependencies = [
  "aes-gcm",
  "criterion",
@@ -454,9 +454,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.136"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55edcf6c0bb319052dea84732cf99db461780fd5e8d3eb46ab6ff312ab31f197"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "log"
@@ -497,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "oorandom"
@@ -515,9 +515,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
 
 [[package]]
 name = "plotters"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "bitflags",
  "clap_lex",
@@ -159,12 +159,12 @@ dependencies = [
 
 [[package]]
 name = "cosmian_crypto_core"
-version = "4.0.1"
+version = "4.1.0"
 dependencies = [
  "aes-gcm",
  "criterion",
  "curve25519-dalek",
- "getrandom 0.2.7",
+ "getrandom 0.2.8",
  "hex",
  "leb128",
  "rand_chacha",
@@ -343,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -454,9 +454,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.135"
+version = "0.2.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+checksum = "55edcf6c0bb319052dea84732cf99db461780fd5e8d3eb46ab6ff312ab31f197"
 
 [[package]]
 name = "log"
@@ -608,7 +608,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom 0.2.8",
 ]
 
 [[package]]
@@ -673,18 +673,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -693,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
+checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
 dependencies = [
  "itoa",
  "ryu",
@@ -720,9 +720,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -731,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Crypto lib for pure crypto primitives"
 edition = "2021"
 license = "MIT/Apache-2.0"
 name = "cosmian_crypto_core"
-version = "4.1.0"
+version = "4.0.1"
 
 [lib]
 crate-type = ["rlib", "staticlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Crypto lib for pure crypto primitives"
 edition = "2021"
 license = "MIT/Apache-2.0"
 name = "cosmian_crypto_core"
-version = "4.0.1"
+version = "4.1.0"
 
 [lib]
 crate-type = ["rlib", "staticlib"]

--- a/src/asymmetric_crypto/curve25519.rs
+++ b/src/asymmetric_crypto/curve25519.rs
@@ -6,7 +6,8 @@
 //! time of this implementation.
 
 use crate::{
-    asymmetric_crypto::DhKeyPair, reexport::rand_core::CryptoRngCore, CryptoCoreError, KeyTrait,
+    asymmetric_crypto::DhKeyPair, bytes_ser_de::Serializable, reexport::rand_core::CryptoRngCore,
+    CryptoCoreError, KeyTrait,
 };
 use core::{
     convert::TryFrom,
@@ -62,6 +63,22 @@ impl KeyTrait<X25519_PRIVATE_KEY_LENGTH> for X25519PrivateKey {
     #[inline]
     fn try_from_bytes(bytes: &[u8]) -> Result<Self, CryptoCoreError> {
         Self::try_from(bytes)
+    }
+}
+
+impl Serializable for X25519PrivateKey {
+    type Error = CryptoCoreError;
+
+    fn length(&self) -> usize {
+        Self::LENGTH
+    }
+
+    fn write(&self, ser: &mut crate::bytes_ser_de::Serializer) -> Result<usize, Self::Error> {
+        ser.write_array(self.as_bytes())
+    }
+
+    fn read(de: &mut crate::bytes_ser_de::Deserializer) -> Result<Self, Self::Error> {
+        Self::try_from(de.read_array::<{ Self::LENGTH }>()?)
     }
 }
 
@@ -198,6 +215,22 @@ impl KeyTrait<X25519_PUBLIC_KEY_LENGTH> for X25519PublicKey {
     #[inline]
     fn try_from_bytes(bytes: &[u8]) -> Result<Self, CryptoCoreError> {
         Self::try_from(bytes)
+    }
+}
+
+impl Serializable for X25519PublicKey {
+    type Error = CryptoCoreError;
+
+    fn length(&self) -> usize {
+        Self::LENGTH
+    }
+
+    fn write(&self, ser: &mut crate::bytes_ser_de::Serializer) -> Result<usize, Self::Error> {
+        ser.write_array(&self.to_bytes())
+    }
+
+    fn read(de: &mut crate::bytes_ser_de::Deserializer) -> Result<Self, Self::Error> {
+        Self::try_from(de.read_array::<{ Self::LENGTH }>()?)
     }
 }
 

--- a/src/bytes_ser_de.rs
+++ b/src/bytes_ser_de.rs
@@ -13,8 +13,7 @@ pub trait Serializable: Sized {
     /// Retrieves the length of the serialized object if it can be known.
     ///
     /// This length will be used to initialize the `Serializer` with the
-    /// correct capacity in `try_to_bytes()`. If `None` is provided, 0 will be
-    /// used.
+    /// correct capacity in `try_to_bytes()`.
     fn length(&self) -> usize;
 
     /// Writes to the given `Serializer`.
@@ -140,6 +139,7 @@ impl Serializer {
     }
 
     /// Generates a new `Serializer` with the given capacity.
+    #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             writable: Vec::with_capacity(capacity),

--- a/src/bytes_ser_de.rs
+++ b/src/bytes_ser_de.rs
@@ -15,10 +15,7 @@ pub trait Serializable: Sized {
     /// This length will be used to initialize the `Serializer` with the
     /// correct capacity in `try_to_bytes()`. If `None` is provided, 0 will be
     /// used.
-    #[must_use]
-    fn length(&self) -> Option<usize> {
-        None
-    }
+    fn length(&self) -> usize;
 
     /// Writes to the given `Serializer`.
     fn write(&self, ser: &mut Serializer) -> Result<usize, Self::Error>;
@@ -29,11 +26,7 @@ pub trait Serializable: Sized {
     /// Serializes the object. Allocates the correct capacity if it is known.
     #[inline]
     fn try_to_bytes(&self) -> Result<Vec<u8>, Self::Error> {
-        let mut ser = if let Some(length) = self.length() {
-            Serializer::with_capacity(length)
-        } else {
-            Serializer::new()
-        };
+        let mut ser = Serializer::with_capacity(self.length());
         self.write(&mut ser)?;
         Ok(ser.finalize())
     }
@@ -120,6 +113,12 @@ impl<'a> Deserializer<'a> {
             ))
         })?;
         Ok(buf)
+    }
+
+    /// Returns a pointer to the underlying value.
+    #[inline]
+    pub fn value(&self) -> &[u8] {
+        self.readable
     }
 
     /// Consumes the `Deserializer` and returns the remaining bytes.


### PR DESCRIPTION
- add `<impl Serializable>::length()`
- add `Serializer::with_capaity()`
- remove `Serializer::value()` (useless)

BREAKING CHANGE: removing of `Serializer::value()`

**Note**: to be reviewed with [the similar MR](https://github.com/Cosmian/cover_crypt/pull/60) on CoverCrypt