### PR TITLE
fix!: internalize `sha3` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 ### Added
 - `<impl Serializable>::length()`
 - `Serializer::with_capacity()`
+- `Serializer::write<impl Serializable>()`
+- `Deserializer::read<impl Serializable>()`
 ### Changed
 - `<impl Serializable>::try_to_bytes()` now allocates
   `<impl Serializable>::length()` bytes to the `Serializer` on creation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - `<impl Serializable>::try_to_bytes()` now allocates
   `<impl Serializable>::length()` bytes to the `Serializer` on creation
+- `kdf!` uses `$crate` local objects => remove `sha3` dependency in caller
 ### Fixed
 ### Removed
 ---

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,12 @@ hex = "0.4"
 leb128 = "0.2.5"
 rand_chacha = "0.3"
 serde = { version = "1.0", features = ["derive"] }
+sha3 = "0.10"
 thiserror = "1.0"
 zeroize = "1.5"
 
 [dev-dependencies]
 criterion = "0.4"
-sha3 = "0.10"
 
 [[bench]]
 name = "benches"

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -1,16 +1,12 @@
 use cosmian_crypto_core::{
     asymmetric_crypto::{curve25519::X25519KeyPair, DhKeyPair},
     kdf,
+    reexport::rand_core::RngCore,
     reexport::rand_core::SeedableRng,
     symmetric_crypto::{aes_256_gcm_pure::Aes256GcmCrypto, key::Key, Dem},
     CsRng, KeyTrait,
 };
 use criterion::{criterion_group, criterion_main, Criterion};
-use rand_chacha::rand_core::RngCore;
-use sha3::{
-    digest::{ExtendableOutput, Update, XofReader},
-    Shake128,
-};
 
 /// Bench the Group-Scalar multiplication on which is based the
 /// Diffie-Hellman key exchange. This gives an indication on how fast

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -7,11 +7,6 @@ use cosmian_crypto_core::{
     symmetric_crypto::{aes_256_gcm_pure::Aes256GcmCrypto, Dem, SymKey},
     CsRng, KeyTrait,
 };
-use sha3::{
-    digest::XofReader,
-    digest::{ExtendableOutput, Update},
-    Shake128,
-};
 
 fn main() {
     // The random generator should be instantiated at the highest possible

--- a/src/kdf.rs
+++ b/src/kdf.rs
@@ -1,3 +1,8 @@
+pub use sha3::{
+    digest::{ExtendableOutput, Update, XofReader},
+    Shake128,
+};
+
 /// Key Derivation Function (KDF).
 ///
 /// Derives the given inputs to the desired length using SHAKE128, which should
@@ -16,11 +21,6 @@
 /// ```
 /// #[macro_use]
 /// use cosmian_crypto_core::kdf;
-///
-/// use sha3::{
-///     digest::{ExtendableOutput, Update, XofReader},
-///     Shake128,
-/// };
 ///
 /// const KEY_LENGTH: usize = 32;
 ///
@@ -41,13 +41,13 @@
 macro_rules! kdf {
     ($length: ident, $($bytes: expr),+) => {
         {
-            let mut hasher = Shake128::default();
+            let mut hasher = $crate::kdf::Shake128::default();
             $(
-                hasher.update($bytes);
+                <$crate::kdf::Shake128 as $crate::kdf::Update>::update(&mut hasher, $bytes);
             )*
-            let mut reader = hasher.finalize_xof();
+            let mut reader = <$crate::kdf::Shake128 as $crate::kdf::ExtendableOutput>::finalize_xof(hasher);
             let mut res = [0; $length];
-            reader.read(&mut res);
+            <<$crate::kdf::Shake128 as $crate::kdf::ExtendableOutput>::Reader as $crate::kdf::XofReader>::read(&mut reader, &mut res);
             res
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub mod reexport {
 }
 pub mod symmetric_crypto;
 
-use reexport::rand_core::{CryptoRng, RngCore};
+use reexport::rand_core::CryptoRngCore;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 pub use crate::error::CryptoCoreError;
@@ -30,7 +30,7 @@ pub trait KeyTrait<const LENGTH: usize>:
 
     /// Generates a new random key.
     #[must_use]
-    fn new<R: RngCore + CryptoRng>(rng: &mut R) -> Self;
+    fn new<R: CryptoRngCore>(rng: &mut R) -> Self;
 
     /// Converts the given key into a vector of bytes.
     #[must_use]


### PR DESCRIPTION
The `sha3` module does not need to be imported in crates calling the `kdf!` macro.

BREAKING CHANGE: breaks dependency