### PR TITLE
Fix/kdf use local imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- use local import of `tinny-keccak` for `kdf!`
+
 ## [9.0.3] - 2023-08-17
 
 ### Bug Fixes

--- a/src/asymmetric_crypto/curve_25519/ed25519/mod.rs
+++ b/src/asymmetric_crypto/curve_25519/ed25519/mod.rs
@@ -6,5 +6,4 @@ mod public_key;
 
 pub use ed_dsa::{Cached25519Signer, Ed25519Keypair};
 pub use private_key::Ed25519PrivateKey;
-pub use public_key::Ed25519PublicKey;
-pub use public_key::ED25519_PUBLIC_KEY_LENGTH;
+pub use public_key::{Ed25519PublicKey, ED25519_PUBLIC_KEY_LENGTH};

--- a/src/asymmetric_crypto/curve_25519/ristretto_25519/mod.rs
+++ b/src/asymmetric_crypto/curve_25519/ristretto_25519/mod.rs
@@ -2,5 +2,4 @@ mod private_key;
 mod public_key;
 
 pub use private_key::R25519PrivateKey;
-pub use public_key::R25519PublicKey;
-pub use public_key::R25519_PUBLIC_KEY_LENGTH;
+pub use public_key::{R25519PublicKey, R25519_PUBLIC_KEY_LENGTH};

--- a/src/asymmetric_crypto/curve_25519/x25519/mod.rs
+++ b/src/asymmetric_crypto/curve_25519/x25519/mod.rs
@@ -1,7 +1,6 @@
 mod public_key;
 
-pub use public_key::X25519PublicKey;
-pub use public_key::X25519_PUBLIC_KEY_LENGTH;
+pub use public_key::{X25519PublicKey, X25519_PUBLIC_KEY_LENGTH};
 
 use super::private_key::Curve25519PrivateKey;
 

--- a/src/kdf.rs
+++ b/src/kdf.rs
@@ -1,3 +1,5 @@
+pub use tiny_keccak::{Hasher, Shake};
+
 /// Key Derivation Function (KDF).
 ///
 /// Derives the given inputs to the desired length using SHAKE128, which should
@@ -40,11 +42,11 @@
 macro_rules! kdf128 {
     ($res: expr, $($bytes: expr),+) => {
         {
-            let mut hasher = tiny_keccak::Shake::v128();
+            let mut hasher = $crate::kdf::Shake::v128();
             $(
-                <tiny_keccak::Shake as tiny_keccak::Hasher>::update(&mut hasher, $bytes);
+                <$crate::kdf::Shake as $crate::kdf::Hasher>::update(&mut hasher, $bytes);
             )*
-            <tiny_keccak::Shake as tiny_keccak::Hasher>::finalize(hasher, $res);
+            <$crate::kdf::Shake as $crate::kdf::Hasher>::finalize(hasher, $res);
         }
     };
 }
@@ -91,11 +93,11 @@ macro_rules! kdf128 {
 macro_rules! kdf256 {
     ($res: expr, $($bytes: expr),+) => {
         {
-            let mut hasher = tiny_keccak::Shake::v256();
+            let mut hasher = $crate::kdf::Shake::v256();
             $(
-                <tiny_keccak::Shake as tiny_keccak::Hasher>::update(&mut hasher, $bytes);
+                <$crate::kdf::Shake as $crate::kdf::Hasher>::update(&mut hasher, $bytes);
             )*
-            <tiny_keccak::Shake as tiny_keccak::Hasher>::finalize(hasher, $res);
+            <$crate::kdf::Shake as $crate::kdf::Hasher>::finalize(hasher, $res);
         }
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub mod bytes_ser_de;
 #[cfg(feature = "ecies")]
 mod ecies;
 #[cfg(feature = "sha3")]
-mod kdf;
+pub mod kdf;
 #[cfg(any(feature = "aes", feature = "chacha", feature = "rfc5649"))]
 mod symmetric_crypto;
 


### PR DESCRIPTION
Use a local import of `tinny-keccak` in the `kdf!` macro so that caller don't need to bother with importing it (nor with knowing the macro internals).

Fixes #50 