### PR TITLE
Complete API for Covercrypt needs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+**/*~

--- a/benches/signature.rs
+++ b/benches/signature.rs
@@ -32,7 +32,7 @@ pub fn bench_ed25519_signature(c: &mut Criterion) {
     });
 
     let signature = private_key.try_sign(&msg).unwrap();
-    let public_key = Ed25519PublicKey::try_from(&private_key).unwrap();
+    let public_key = Ed25519PublicKey::from(&private_key);
 
     c.bench_function("Ed25519 signature verification", |b| {
         b.iter(|| public_key.verify(&msg, &signature).unwrap());

--- a/examples/examples/signature.rs
+++ b/examples/examples/signature.rs
@@ -18,7 +18,7 @@ pub fn ed25519_static() {
     let signature = private_key.try_sign(message).unwrap();
 
     // verify the signature with the public key
-    let public_key = Ed25519PublicKey::try_from(&private_key).unwrap();
+    let public_key = Ed25519PublicKey::from(&private_key);
     public_key.verify(message, &signature).unwrap();
 
     println!("Ed25519 static: OK");
@@ -41,7 +41,7 @@ pub fn ed25519_cached() {
     let cached_signer = Cached25519Signer::try_from(&private_key).unwrap();
 
     // verify the signatures
-    let public_key = Ed25519PublicKey::try_from(&private_key).unwrap();
+    let public_key = Ed25519PublicKey::from(&private_key);
 
     let message = b"Hello, world!";
     let signature = cached_signer.try_sign(message).unwrap();

--- a/src/asymmetric_crypto/curves/curve_25519/ed25519/certificate/mod.rs
+++ b/src/asymmetric_crypto/curves/curve_25519/ed25519/certificate/mod.rs
@@ -2,7 +2,6 @@ mod encoding;
 
 use std::{str::FromStr, time::Duration};
 
-pub use encoding::ED25519_ALGORITHM_ID;
 use pkcs8::{
     der::{Decode, EncodePem},
     spki::SubjectPublicKeyInfoOwned,

--- a/src/asymmetric_crypto/curves/curve_25519/ed25519/ed_dsa/mod.rs
+++ b/src/asymmetric_crypto/curves/curve_25519/ed25519/ed_dsa/mod.rs
@@ -30,7 +30,7 @@ mod tests {
         let signature = private_key.try_sign(message).unwrap();
 
         // verify the signature
-        let public_key = Ed25519PublicKey::try_from(&private_key).unwrap();
+        let public_key = Ed25519PublicKey::from(&private_key);
         public_key.verify(message, &signature).unwrap();
     }
 
@@ -43,7 +43,7 @@ mod tests {
         let cached_signer = Cached25519Signer::try_from(&private_key).unwrap();
 
         // verify the signatures
-        let public_key = Ed25519PublicKey::try_from(&private_key).unwrap();
+        let public_key = Ed25519PublicKey::from(&private_key);
 
         let message = b"Hello, world!";
         let signature = cached_signer.try_sign(message).unwrap();

--- a/src/asymmetric_crypto/curves/curve_25519/ed25519/ed_dsa/signer.rs
+++ b/src/asymmetric_crypto/curves/curve_25519/ed25519/ed_dsa/signer.rs
@@ -1,5 +1,4 @@
 use ed25519_dalek::{ed25519, SigningKey};
-pub use ed25519_dalek::{SecretKey as EdSecretKey, VerifyingKey as EdPublicKey};
 use signature::Signer;
 
 use crate::Ed25519PrivateKey;

--- a/src/asymmetric_crypto/curves/curve_25519/ed25519/ed_dsa/verifier.rs
+++ b/src/asymmetric_crypto/curves/curve_25519/ed25519/ed_dsa/verifier.rs
@@ -1,5 +1,4 @@
 use ed25519_dalek::ed25519;
-pub use ed25519_dalek::{SecretKey as EdSecretKey, VerifyingKey as EdPublicKey};
 use signature::Verifier;
 
 use crate::Ed25519PublicKey;

--- a/src/asymmetric_crypto/curves/curve_25519/ed25519/private_key.rs
+++ b/src/asymmetric_crypto/curves/curve_25519/ed25519/private_key.rs
@@ -1,5 +1,3 @@
-pub use ed25519_dalek::{SecretKey as EdSecretKey, VerifyingKey as EdPublicKey};
-
 use crate::Curve25519Secret;
 
 pub type Ed25519PrivateKey = Curve25519Secret;

--- a/src/asymmetric_crypto/curves/curve_25519/ed25519/public_key.rs
+++ b/src/asymmetric_crypto/curves/curve_25519/ed25519/public_key.rs
@@ -3,7 +3,7 @@
 use std::ops::Deref;
 
 use ed25519_dalek::SigningKey;
-pub use ed25519_dalek::{SecretKey as EdSecretKey, VerifyingKey as EdPublicKey};
+pub use ed25519_dalek::VerifyingKey as EdPublicKey;
 
 use super::private_key::Ed25519PrivateKey;
 use crate::{CBytes, CryptoCoreError, FixedSizeCBytes};

--- a/src/asymmetric_crypto/curves/curve_25519/ristretto_25519/curve_point.rs
+++ b/src/asymmetric_crypto/curves/curve_25519/ristretto_25519/curve_point.rs
@@ -3,6 +3,7 @@ use core::ops::{Add, Mul, Sub};
 use curve25519_dalek::{
     constants,
     ristretto::{CompressedRistretto, RistrettoPoint},
+    traits::Identity,
 };
 
 use super::R25519PrivateKey;
@@ -122,6 +123,12 @@ impl R25519CurvePoint {
     /// Facade to [`FixedSizeCBytes::try_from_slice`].
     pub fn try_from_slice(slice: &[u8]) -> Result<Self, CryptoCoreError> {
         <Self as FixedSizeCBytes<R25519_CURVE_POINT_LENGTH>>::try_from_slice(slice)
+    }
+
+    /// Returns the identity element of the curve.
+    #[must_use]
+    pub fn identity() -> Self {
+        Self(RistrettoPoint::identity())
     }
 }
 

--- a/src/asymmetric_crypto/curves/curve_25519/ristretto_25519/curve_point.rs
+++ b/src/asymmetric_crypto/curves/curve_25519/ristretto_25519/curve_point.rs
@@ -5,6 +5,7 @@ use curve25519_dalek::{
     ristretto::{CompressedRistretto, RistrettoPoint},
     traits::Identity,
 };
+use zeroize::Zeroize;
 
 use super::R25519PrivateKey;
 #[cfg(feature = "ser")]
@@ -15,7 +16,7 @@ use crate::{CBytes, CryptoCoreError, FixedSizeCBytes};
 ///
 /// Internally, a Ristretto point is used. It wraps an Edwards point and its
 /// compressed form is used for serialization, which makes it 256-bit long.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Zeroize)]
 pub struct R25519CurvePoint(pub(crate) RistrettoPoint);
 
 impl CBytes for R25519CurvePoint {}

--- a/src/asymmetric_crypto/curves/curve_25519/ristretto_25519/mod.rs
+++ b/src/asymmetric_crypto/curves/curve_25519/ristretto_25519/mod.rs
@@ -4,7 +4,7 @@ mod private_key;
 pub use curve_point::{R25519CurvePoint, R25519_CURVE_POINT_LENGTH};
 pub use private_key::{R25519PrivateKey, R25519_PRIVATE_KEY_LENGTH};
 
-// The public key is a Curve Point
+/// The public key is a Curve Point
 pub type R25519PublicKey = R25519CurvePoint;
 /// Length of a Ristretto public key in bytes.
 pub const R25519_PUBLIC_KEY_LENGTH: usize = R25519_CURVE_POINT_LENGTH;

--- a/src/asymmetric_crypto/curves/curve_25519/ristretto_25519/private_key.rs
+++ b/src/asymmetric_crypto/curves/curve_25519/ristretto_25519/private_key.rs
@@ -101,11 +101,13 @@ impl R25519PrivateKey {
     }
 
     /// Neutral scalar element for the addition.
+    #[inline(always)]
     pub const fn zero() -> Self {
         Self(Scalar::ZERO)
     }
 
     /// Neutral scalar element for the multiplication.
+    #[inline(always)]
     pub const fn one() -> Self {
         Self(Scalar::ONE)
     }

--- a/src/asymmetric_crypto/curves/curve_25519/ristretto_25519/private_key.rs
+++ b/src/asymmetric_crypto/curves/curve_25519/ristretto_25519/private_key.rs
@@ -99,6 +99,16 @@ impl R25519PrivateKey {
     pub fn try_from_bytes(bytes: [u8; R25519_PRIVATE_KEY_LENGTH]) -> Result<Self, CryptoCoreError> {
         <Self as FixedSizeCBytes<R25519_PRIVATE_KEY_LENGTH>>::try_from_bytes(bytes)
     }
+
+    /// Neutral scalar element for the addition.
+    pub const fn zero() -> Self {
+        Self(Scalar::ZERO)
+    }
+
+    /// Neutral scalar element for the multiplication.
+    pub const fn one() -> Self {
+        Self(Scalar::ONE)
+    }
 }
 
 // Curve arithmetic

--- a/src/ecies/curve_25519/ecies_x25519_xchacha20.rs
+++ b/src/ecies/curve_25519/ecies_x25519_xchacha20.rs
@@ -6,7 +6,7 @@ use crate::{
     blake2b,
     reexport::rand_core::CryptoRngCore,
     symmetric_crypto::{Dem, DemStream, Instantiable, Nonce, SymmetricKey, XChaCha20Poly1305},
-    CryptoCoreError, Ecies, EciesStream, X25519PrivateKey, X25519PublicKey,
+    CryptoCoreError, Ecies, EciesStream, FixedSizeCBytes, X25519PrivateKey, X25519PublicKey,
     CURVE_25519_SECRET_LENGTH, X25519_PUBLIC_KEY_LENGTH,
 };
 
@@ -33,9 +33,9 @@ fn get_ephemeral_key<const KEY_LENGTH: usize>(
         &GenericArray::default(),
     );
 
-    Ok(SymmetricKey(key.as_slice().try_into().map_err(|_| {
+    SymmetricKey::try_from_bytes(key.as_slice().try_into().map_err(|_| {
         CryptoCoreError::InvalidBytesLength("get ephemeral key".to_string(), KEY_LENGTH, None)
-    })?))
+    })?)
 }
 
 impl EciesX25519XChaCha20 {

--- a/src/ecies/generic_ecies_aes128gcm.rs
+++ b/src/ecies/generic_ecies_aes128gcm.rs
@@ -44,8 +44,8 @@ fn get_ephemeral_key<
 >(
     shared_point: &PublicKey::SharedPoint,
 ) -> SymmetricKey<KEY_LENGTH> {
-    let mut key = SymmetricKey([0; KEY_LENGTH]);
-    kdf128!(&mut key.0, &shared_point.to_vec());
+    let mut key = SymmetricKey::default();
+    kdf128!(&mut *key, &shared_point.to_vec());
     key
 }
 

--- a/src/ecies/nist_curves/mod.rs
+++ b/src/ecies/nist_curves/mod.rs
@@ -1,5 +1,4 @@
 mod keys;
-pub use keys::*;
 
 use crate::{
     EciesAes128, P192PublicKey, P224PublicKey, P256PublicKey, P384PublicKey,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ mod ecies;
 pub mod kdf;
 #[cfg(any(feature = "certificate", feature = "rsa", feature = "nist_curves"))]
 mod pkcs8_fix;
+mod secret;
 #[cfg(any(feature = "aes", feature = "chacha", feature = "rfc5649"))]
 mod symmetric_crypto;
 
@@ -41,6 +42,7 @@ pub use ecies::*;
 #[cfg(feature = "sha3")]
 pub use kdf::*;
 use reexport::rand_core::CryptoRngCore;
+pub use secret::Secret;
 #[cfg(any(feature = "aes", feature = "chacha"))]
 pub use symmetric_crypto::*;
 use zeroize::{Zeroize, ZeroizeOnDrop};

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -6,6 +6,7 @@ use std::{
 use rand_core::CryptoRngCore;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
+#[cfg(feature = "ser")]
 use crate::{bytes_ser_de::Serializable, CryptoCoreError};
 
 /// Holds a secret information of `LENGTH` bytes.
@@ -92,6 +93,7 @@ impl<const LENGTH: usize> Drop for Secret<LENGTH> {
 
 impl<const LENGTH: usize> ZeroizeOnDrop for Secret<LENGTH> {}
 
+#[cfg(feature = "ser")]
 impl<const LENGTH: usize> Serializable for Secret<LENGTH> {
     type Error = CryptoCoreError;
 

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -1,0 +1,113 @@
+use std::{
+    ops::{Deref, DerefMut},
+    pin::Pin,
+};
+
+use rand_core::CryptoRngCore;
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+use crate::{bytes_ser_de::Serializable, CryptoCoreError};
+
+/// Holds a secret information of `LENGTH` bytes.
+///
+/// This secret is stored on the heap and is guaranteed to be zeroized on drop.
+#[derive(Debug, Eq, PartialEq, Clone, Hash)]
+pub struct Secret<const LENGTH: usize>(Pin<Box<[u8; LENGTH]>>);
+
+impl<const LENGTH: usize> Secret<LENGTH> {
+    /// Creates a new secret and returns it.
+    ///
+    /// All bytes are initially set to 0.
+    #[inline(always)]
+    pub fn new() -> Self {
+        Self(Box::pin([0; LENGTH]))
+    }
+
+    /// Creates a new random secret using the given RNG.
+    pub fn random(rng: &mut impl CryptoRngCore) -> Self {
+        let mut secret = Self::new();
+        rng.fill_bytes(&mut secret);
+        secret
+    }
+
+    /// Returns the bytes of the secret.
+    ///
+    /// # Safety
+    ///
+    /// Once returned the secret bytes are *not* protected. It is the caller's
+    /// responsibility to guarantee they are not leaked in the memory.
+    #[inline(always)]
+    pub fn to_unprotected_bytes(&self, dest: &mut [u8; LENGTH]) {
+        dest.copy_from_slice(self);
+    }
+
+    /// Creates a secret from the given unprotected bytes, and zeroizes the
+    /// source bytes.
+    ///
+    /// Do not take ownership of the bytes to avoid stack copying.
+    pub fn from_unprotected_bytes(bytes: &mut [u8; LENGTH]) -> Self {
+        let mut secret = Self::new();
+        secret.copy_from_slice(bytes.as_slice());
+        bytes.zeroize();
+        secret
+    }
+}
+
+impl<const LENGTH: usize> Default for Secret<LENGTH> {
+    #[inline(always)]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const LENGTH: usize> Deref for Secret<LENGTH> {
+    type Target = [u8];
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        &*self.0
+    }
+}
+
+impl<const LENGTH: usize> DerefMut for Secret<LENGTH> {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut *self.0
+    }
+}
+
+impl<const LENGTH: usize> Zeroize for Secret<LENGTH> {
+    #[inline(always)]
+    fn zeroize(&mut self) {
+        self.0.deref_mut().zeroize()
+    }
+}
+
+impl<const LENGTH: usize> Drop for Secret<LENGTH> {
+    #[inline(always)]
+    fn drop(&mut self) {
+        self.zeroize()
+    }
+}
+
+impl<const LENGTH: usize> ZeroizeOnDrop for Secret<LENGTH> {}
+
+impl<const LENGTH: usize> Serializable for Secret<LENGTH> {
+    type Error = CryptoCoreError;
+
+    #[inline(always)]
+    fn length(&self) -> usize {
+        LENGTH
+    }
+
+    #[inline(always)]
+    fn write(&self, ser: &mut crate::bytes_ser_de::Serializer) -> Result<usize, Self::Error> {
+        ser.write_array(self)
+    }
+
+    #[inline(always)]
+    fn read(de: &mut crate::bytes_ser_de::Deserializer) -> Result<Self, Self::Error> {
+        let mut bytes = de.read_array::<LENGTH>()?;
+        Ok(Self::from_unprotected_bytes(&mut bytes))
+    }
+}


### PR DESCRIPTION
- add neutral (one and zero) scalar for Curve25519;
- add neutral (zero) point for Curve25519;
- add `Secret` type to store sensitive bytes that are not keys, based on a zeroized implementation of a pinned box containing a fixed-length array.

As an example, the `SymetricKey` is rewritten based on the `Secret` type. If this MR is accepted, re-implementation of sensitive buffers to use the `Secret` type should to be planned. It can serve to return plaintext and to implement asymmetric keys.

**Note**: the current implementation of the keys is *not* secure as passing ownership of the current keys implies stack copying, which is not zeroized (we currently zeroize on drop only).