### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ blake2 = { version = "0.10", optional = true }
 chacha20 = { version = "0.9", optional = true }
 chacha20poly1305 = { version = "0.10", optional = true }
 crypto_box = { version = "0.9.1", features = ["seal"], optional = true }
-curve25519-dalek = { version = "4.1.0", optional = true }
+curve25519-dalek = { version = "4.1.3", optional = true }
 digest = { version = "0.10", optional = true }
 ed25519-dalek = { version = "2.0.0", optional = true, features = [
     "default",


### PR DESCRIPTION
Bumps the dependency to at least 4.1.3 as per the advisory

[Advisory](https://rustsec.org/advisories/RUSTSEC-2024-0344.html) 

(even though this crate may not be using the function mentioned in the advisory, it is better to bump it to ensure that there is no chance of other dependencies pulling it)