### PR TITLE
Fix array deserialization

### DIFF
--- a/src/asymmetric_crypto/rsa/mod.rs
+++ b/src/asymmetric_crypto/rsa/mod.rs
@@ -44,9 +44,8 @@ pub enum RsaKeyWrappingAlgorithm {
     /// The hash function used is SHA1. For that reason this algorithm is not
     /// recommended and is only kept here for compatibility with legacy
     /// systems. The maximum possible plaintext length is m = k - 2 * h_len
-    /// - 2, where k is the size of the RSA modulus
-    /// and h_len is the size of the hash of the optional label.
-    /// This algorithm is compatible with Google Cloud KMS
+    /// - 2, where k is the size of the RSA modulus and h_len is the size of the hash of the
+    ///   optional label. This algorithm is compatible with Google Cloud KMS
     ///  - RSA_OAEP_3072_SHA256 with RSA 3072 bits key
     ///  - RSA_OAEP_4096_SHA256 with RSA 4096 bits key
     OaepSha1,

--- a/src/ecies/generic_ecies_aes128gcm.rs
+++ b/src/ecies/generic_ecies_aes128gcm.rs
@@ -245,7 +245,7 @@ impl<
     }
 }
 
-#[cfg(all(test, feature = "nist_curves", feature = "curve_25519"))]
+#[cfg(all(test, feature = "nist_curves", feature = "curve25519"))]
 mod tests {
     use aead::Payload;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,10 @@ pub enum CryptoCoreError {
     ConversionError(String),
     DecryptionError,
     DeserializationEmptyError,
+    DeserializationIoError {
+        bytes_len: usize,
+        error: String,
+    },
     DeserializationSizeError {
         given: usize,
         expected: usize,
@@ -107,6 +111,9 @@ impl Display for CryptoCoreError {
             CryptoCoreError::ReadLeb128Error(err) => write!(f, "when reading LEB128, {err}"),
             #[cfg(feature = "rsa")]
             CryptoCoreError::RsaError(e) => write!(f, "RSA error: {e}"),
+            CryptoCoreError::DeserializationIoError { bytes_len, error } => {
+                write!(f, "when reading {bytes_len} bytes, {error}")
+            }
             CryptoCoreError::SerializationIoError { bytes_len, error } => {
                 write!(f, "when writing {bytes_len} bytes, {error}")
             }

--- a/src/symmetric_crypto/dem.rs
+++ b/src/symmetric_crypto/dem.rs
@@ -40,7 +40,7 @@ pub trait Dem<
     /// - `nonce`       : the Nonce to use
     /// - `plaintext`   : plaintext message
     /// - `aad`         : optional data to use in the authentication method,
-    /// must use the same for decryption
+    ///   must use the same for decryption
     fn encrypt(
         &self,
         nonce: &Self::Nonce,
@@ -65,7 +65,7 @@ pub trait Dem<
     /// - `nonce`       : the Nonce to use
     /// - `ciphertext`  : ciphertext message
     /// - `aad`         : optional data to use in the authentication method,
-    /// must use the same for encryption
+    ///   must use the same for encryption
     fn decrypt(
         &self,
         nonce: &Self::Nonce,


### PR DESCRIPTION
Fixes a bug that has been present since commit `88eaa5fc`: upon attempting to deserialize an array while not being given enough bytes, `read()` would return an incorrect error message, which contains erroneous information about the bug.

Also, fixes a mistyped feature name in `cfg(feature = "...")` macro that was effectively commenting out a full portion of tests.

I suggest checking out the CI since both these issue have been present since ~v6.0.0 without being detected (while a local `cargo test` was enough to raise this bug).