### PR TITLE
Feat deref with length

### DIFF
--- a/src/asymmetric_crypto/rsa/public_key.rs
+++ b/src/asymmetric_crypto/rsa/public_key.rs
@@ -95,7 +95,7 @@ fn ckm_rsa_aes_key_wrap<
     // Wraps the target key with the temporary AES key using CKM_AES_KEY_WRAP_KWP
     // ([AES KEYWRAP] section 6.3). PKCS#11 CKM_AES_KEY_WRAP_KWP is identical to
     // tRFC 5649
-    let mut ciphertext = key_wrap(key_material, &key_encryption_key)?;
+    let mut ciphertext = key_wrap(key_material, &*key_encryption_key)?;
     //Wraps the AES key with the wrapping RSA key using CKM_RSA_PKCS_OAEP with
     // parameters of OAEPParams. Zeroizes the temporary AES key (automatically
     // done by the conversion into())

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -27,7 +27,7 @@ impl<const LENGTH: usize> Secret<LENGTH> {
     /// Creates a new random secret using the given RNG.
     pub fn random(rng: &mut impl CryptoRngCore) -> Self {
         let mut secret = Self::new();
-        rng.fill_bytes(&mut secret);
+        rng.fill_bytes(&mut *secret);
         secret
     }
 
@@ -39,7 +39,7 @@ impl<const LENGTH: usize> Secret<LENGTH> {
     /// responsibility to guarantee they are not leaked in the memory.
     #[inline(always)]
     pub fn to_unprotected_bytes(&self, dest: &mut [u8; LENGTH]) {
-        dest.copy_from_slice(self);
+        dest.copy_from_slice(&**self);
     }
 
     /// Creates a secret from the given unprotected bytes, and zeroizes the
@@ -62,18 +62,18 @@ impl<const LENGTH: usize> Default for Secret<LENGTH> {
 }
 
 impl<const LENGTH: usize> Deref for Secret<LENGTH> {
-    type Target = [u8];
+    type Target = [u8; LENGTH];
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        &*self.0
+        &self.0
     }
 }
 
 impl<const LENGTH: usize> DerefMut for Secret<LENGTH> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut *self.0
+        &mut self.0
     }
 }
 
@@ -104,7 +104,7 @@ impl<const LENGTH: usize> Serializable for Secret<LENGTH> {
 
     #[inline(always)]
     fn write(&self, ser: &mut crate::bytes_ser_de::Serializer) -> Result<usize, Self::Error> {
-        ser.write_array(self)
+        ser.write_array(&**self)
     }
 
     #[inline(always)]

--- a/src/symmetric_crypto/key.rs
+++ b/src/symmetric_crypto/key.rs
@@ -48,7 +48,7 @@ impl<const LENGTH: usize> RandomFixedSizeCBytes<LENGTH> for SymmetricKey<LENGTH>
 impl<const LENGTH: usize> SecretCBytes<LENGTH> for SymmetricKey<LENGTH> {}
 
 impl<const LENGTH: usize> Deref for SymmetricKey<LENGTH> {
-    type Target = [u8];
+    type Target = [u8; LENGTH];
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -94,7 +94,7 @@ impl<const KEY_LENGTH: usize> SymmetricKey<KEY_LENGTH> {
             )));
         }
         let mut key = Self::default();
-        kdf256!(&mut key, &secret, info);
+        kdf256!(&mut *key, &**secret, info);
         Ok(key)
     }
 }


### PR DESCRIPTION
Upon de-referencing a `Secret` or a `SymmetricKey`, use `&[u8; LENGTH]` instead of `&[u8]`.

Rational: this makes de-referencing to a byte of slice more verbose but allows writing something like that, which relies on the type system to guarantee byte-array lengths:

```rust
fn xor<const LENGTH: usize>(out: &mut [u8; LENGTH], lhs: &[u8; LENGTH], rhs: &[u8; LENGTH]) {
    for i in 0..LENGTH {
        out[i] = lhs[i] ^ rhs[i];
    }
}

[...]

let k1 : Secret<SOME_LENGTH> = ...;
let k2 : Secret<SOME_LENGTH> = ...;
let mut k = Secret::<SOME_LENGTH>::default();
xor(&mut k, &k1, &k2);
```