### PR TITLE
Some more features

### DIFF
--- a/src/asymmetric_crypto/curves/curve_25519/ristretto_25519/curve_point.rs
+++ b/src/asymmetric_crypto/curves/curve_25519/ristretto_25519/curve_point.rs
@@ -1,4 +1,5 @@
 use core::ops::{Add, Mul, Sub};
+use std::iter::Sum;
 
 use curve25519_dalek::{
     constants,
@@ -129,6 +130,20 @@ impl R25519CurvePoint {
     #[must_use]
     pub fn identity() -> Self {
         Self(RistrettoPoint::identity())
+    }
+}
+
+impl<'a> Add<&'a R25519CurvePoint> for R25519CurvePoint {
+    type Output = R25519CurvePoint;
+
+    fn add(self, rhs: &'a R25519CurvePoint) -> Self::Output {
+        Self(self.0 + rhs.0)
+    }
+}
+
+impl<'a> Sum<&'a R25519CurvePoint> for R25519CurvePoint {
+    fn sum<I: Iterator<Item = &'a R25519CurvePoint>>(iter: I) -> Self {
+        iter.fold(Self::identity(), Add::add)
     }
 }
 

--- a/src/asymmetric_crypto/rsa/public_key.rs
+++ b/src/asymmetric_crypto/rsa/public_key.rs
@@ -95,7 +95,7 @@ fn ckm_rsa_aes_key_wrap<
     // Wraps the target key with the temporary AES key using CKM_AES_KEY_WRAP_KWP
     // ([AES KEYWRAP] section 6.3). PKCS#11 CKM_AES_KEY_WRAP_KWP is identical to
     // tRFC 5649
-    let mut ciphertext = key_wrap(key_material, &key_encryption_key)?;
+    let mut ciphertext = key_wrap(key_material, &*key_encryption_key)?;
     //Wraps the AES key with the wrapping RSA key using CKM_RSA_PKCS_OAEP with
     // parameters of OAEPParams. Zeroizes the temporary AES key (automatically
     // done by the conversion into())

--- a/src/bytes_ser_de.rs
+++ b/src/bytes_ser_de.rs
@@ -265,7 +265,7 @@ pub fn test_serialization<T: PartialEq + Debug + Serializable>(v: &T) -> Result<
         ));
     }
     if v != &w {
-        return Err("incorrect deserialization".to_string());
+        return Err(format!("incorrect deserialization: {:?} != {:?}", v, w));
     }
     if bytes.len() != w.length() {
         return Err(format!(

--- a/src/ecies/curve_25519/r25519.rs
+++ b/src/ecies/curve_25519/r25519.rs
@@ -9,11 +9,13 @@ impl EciesEcPrivateKey<R25519_PRIVATE_KEY_LENGTH> for R25519PrivateKey {
         <Self as RandomFixedSizeCBytes<{ R25519_PRIVATE_KEY_LENGTH }>>::new(rng)
     }
 }
+
 impl EciesEcSharedPoint for R25519PublicKey {
     fn to_vec(&self) -> Vec<u8> {
         <Self as FixedSizeCBytes<R25519_PUBLIC_KEY_LENGTH>>::to_bytes(self).to_vec()
     }
 }
+
 impl EciesEcPublicKey<R25519_PRIVATE_KEY_LENGTH, R25519_PUBLIC_KEY_LENGTH> for R25519CurvePoint {
     type PrivateKey = R25519PrivateKey;
     type SharedPoint = Self;

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -27,7 +27,7 @@ impl<const LENGTH: usize> Secret<LENGTH> {
     /// Creates a new random secret using the given RNG.
     pub fn random(rng: &mut impl CryptoRngCore) -> Self {
         let mut secret = Self::new();
-        rng.fill_bytes(&mut secret);
+        rng.fill_bytes(&mut *secret);
         secret
     }
 
@@ -39,7 +39,7 @@ impl<const LENGTH: usize> Secret<LENGTH> {
     /// responsibility to guarantee they are not leaked in the memory.
     #[inline(always)]
     pub fn to_unprotected_bytes(&self, dest: &mut [u8; LENGTH]) {
-        dest.copy_from_slice(self);
+        dest.copy_from_slice(&**self);
     }
 
     /// Creates a secret from the given unprotected bytes, and zeroizes the
@@ -62,18 +62,18 @@ impl<const LENGTH: usize> Default for Secret<LENGTH> {
 }
 
 impl<const LENGTH: usize> Deref for Secret<LENGTH> {
-    type Target = [u8];
+    type Target = [u8; LENGTH];
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        &*self.0
+        &self.0
     }
 }
 
 impl<const LENGTH: usize> DerefMut for Secret<LENGTH> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut *self.0
+        &mut self.0
     }
 }
 
@@ -104,7 +104,7 @@ impl<const LENGTH: usize> Serializable for Secret<LENGTH> {
 
     #[inline(always)]
     fn write(&self, ser: &mut crate::bytes_ser_de::Serializer) -> Result<usize, Self::Error> {
-        ser.write_array(self)
+        ser.write_array(&**self)
     }
 
     #[inline(always)]

--- a/src/symmetric_crypto/key.rs
+++ b/src/symmetric_crypto/key.rs
@@ -48,7 +48,7 @@ impl<const LENGTH: usize> RandomFixedSizeCBytes<LENGTH> for SymmetricKey<LENGTH>
 impl<const LENGTH: usize> SecretCBytes<LENGTH> for SymmetricKey<LENGTH> {}
 
 impl<const LENGTH: usize> Deref for SymmetricKey<LENGTH> {
-    type Target = [u8];
+    type Target = [u8; LENGTH];
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -94,7 +94,7 @@ impl<const KEY_LENGTH: usize> SymmetricKey<KEY_LENGTH> {
             )));
         }
         let mut key = Self::default();
-        kdf256!(&mut key, &secret, info);
+        kdf256!(&mut *key, &**secret, info);
         Ok(key)
     }
 }


### PR DESCRIPTION
This PR:
- adds implementation of some arithmetic operations for curve points,
- exports a method for raw bytes conversion to `R25519PrivateKey`
- adds a generic serialization test that can be used by any type implementing `Serializable`,
- requires the `Serializable::Error` to implement `std::error::Error`,
- modifies the `Deref` implementations for the secrets and keys so that one can access to reference on arrays instead of slices (needed to be compatible with fixed-length byte parsing)
