### PR TITLE
ci: fix wasm build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@1.83.0
         with:
-          toolchain: stable
-          target: wasm32-unknown-unknown
-          override: true
+          components: rustfmt, clippy
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --verbose --target wasm32-unknown-unknown
+        run: |
+          rustup target add wasm32-unknown-unknown
+          cargo build --target wasm32-unknown-unknown
   hack:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ sha2 = { version = "0.10", optional = true }
 sha3 = { version = "0.10", optional = true }
 signature = { version = "2.2", optional = true }
 tiny-keccak = { version = "2.0.2", features = ["shake"], optional = true }
-uuid = { version = "1.11", features = ["v4"], optional = true }
+uuid = { version = "=1.11", features = ["v4"], optional = true }
 x509-cert = { version = "0.2.5", features = [
     "pem",
     "std",


### PR DESCRIPTION
- freeze version of crate `uuid` which raises an error in recent version (>= 1.13.2)