### PR TITLE
always expose the symmetric key

### DIFF
--- a/src/ecies/curve_25519/ecies_x25519_xchacha20.rs
+++ b/src/ecies/curve_25519/ecies_x25519_xchacha20.rs
@@ -5,9 +5,9 @@ use chacha20poly1305::XChaCha20Poly1305 as XChaCha20Poly1305Lib;
 use crate::{
     blake2b,
     reexport::rand_core::CryptoRngCore,
-    symmetric_crypto::{Dem, DemStream, Instantiable, Nonce, SymmetricKey, XChaCha20Poly1305},
-    CryptoCoreError, Ecies, EciesStream, FixedSizeCBytes, X25519PrivateKey, X25519PublicKey,
-    CURVE_25519_SECRET_LENGTH, X25519_PUBLIC_KEY_LENGTH,
+    symmetric_crypto::{Dem, DemStream, Instantiable, Nonce, XChaCha20Poly1305},
+    CryptoCoreError, Ecies, EciesStream, FixedSizeCBytes, SymmetricKey, X25519PrivateKey,
+    X25519PublicKey, CURVE_25519_SECRET_LENGTH, X25519_PUBLIC_KEY_LENGTH,
 };
 
 /// A thread safe Elliptic Curve Integrated Encryption Scheme (ECIES) using

--- a/src/ecies/generic_ecies_aes128gcm.rs
+++ b/src/ecies/generic_ecies_aes128gcm.rs
@@ -5,8 +5,8 @@ use crate::{
     ecies::traits::{EciesEcPrivateKey, EciesEcPublicKey, EciesEcSharedPoint},
     kdf128,
     reexport::rand_core::CryptoRngCore,
-    symmetric_crypto::{Aes128Gcm, Dem, DemStream, Instantiable, Nonce, SymmetricKey},
-    CryptoCoreError, Ecies,
+    symmetric_crypto::{Aes128Gcm, Dem, DemStream, Instantiable, Nonce},
+    CryptoCoreError, Ecies, SymmetricKey,
 };
 
 /// A thread safe Elliptic Curve Integrated Encryption Scheme (ECIES) using

--- a/src/key.rs
+++ b/src/key.rs
@@ -102,10 +102,7 @@ impl<const KEY_LENGTH: usize> SymmetricKey<KEY_LENGTH> {
 #[cfg(test)]
 mod tests {
 
-    use crate::{
-        reexport::rand_core::SeedableRng, symmetric_crypto::key::SymmetricKey, CsRng,
-        RandomFixedSizeCBytes,
-    };
+    use crate::{reexport::rand_core::SeedableRng, CsRng, RandomFixedSizeCBytes, SymmetricKey};
 
     const KEY_LENGTH: usize = 32;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,21 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 /// Use `ChaCha` with 12 rounds as cryptographic RNG.
 pub type CsRng = rand_chacha::ChaCha12Rng;
 
+/// Shuffles the given slice in a destructive way.
+pub fn shuffle_in_place<X>(xs: &mut [X], rng: &mut impl CryptoRngCore) {
+    for i in 0..xs.len() {
+        let j = rng.next_u32() as usize % xs.len();
+        xs.swap(i, j);
+    }
+}
+
+/// Returns a vector containing a shuffled copy of the given elements.
+pub fn shuffle<X: Clone>(xs: &[X], rng: &mut impl CryptoRngCore) -> Vec<X> {
+    let mut res = xs.to_vec();
+    shuffle_in_place(&mut res, rng);
+    res
+}
+
 /// Cryptographic bytes
 ///
 /// The bytes should be thread-safe and comparable.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,8 @@ pub mod bytes_ser_de;
 mod ecies;
 #[cfg(feature = "sha3")]
 pub mod kdf;
-#[cfg(any(feature = "certificate", feature = "rsa", feature = "nist_curves"))]
+mod key;
+#[cfg(any(feature = "rsa", feature = "nist_curves"))]
 mod pkcs8_fix;
 mod secret;
 #[cfg(any(feature = "aes", feature = "chacha", feature = "rfc5649"))]
@@ -41,6 +42,7 @@ pub use asymmetric_crypto::*;
 pub use ecies::*;
 #[cfg(feature = "sha3")]
 pub use kdf::*;
+pub use key::SymmetricKey;
 use reexport::rand_core::CryptoRngCore;
 pub use secret::Secret;
 #[cfg(any(feature = "aes", feature = "chacha"))]

--- a/src/symmetric_crypto/aes_128_gcm.rs
+++ b/src/symmetric_crypto/aes_128_gcm.rs
@@ -11,10 +11,7 @@ use super::{
     dem::{DemInPlace, DemStream, Instantiable},
     nonce::Nonce,
 };
-use crate::{
-    symmetric_crypto::{key::SymmetricKey, Dem},
-    RandomFixedSizeCBytes,
-};
+use crate::{symmetric_crypto::Dem, RandomFixedSizeCBytes, SymmetricKey};
 
 /// Structure implementing `SymmetricCrypto` and the `DEM` interfaces based on
 /// AES 128 GCM.
@@ -90,11 +87,10 @@ mod tests {
         symmetric_crypto::{
             aes_128_gcm::Aes128Gcm,
             dem::{DemStream, Instantiable},
-            key::SymmetricKey,
             nonce::Nonce,
             Dem, DemInPlace,
         },
-        CryptoCoreError, CsRng, RandomFixedSizeCBytes,
+        CryptoCoreError, CsRng, RandomFixedSizeCBytes, SymmetricKey,
     };
 
     #[test]

--- a/src/symmetric_crypto/aes_256_gcm.rs
+++ b/src/symmetric_crypto/aes_256_gcm.rs
@@ -12,8 +12,8 @@ use aes_gcm::Aes256Gcm as Aes256GcmLib;
 
 use super::dem::{DemInPlace, DemStream, Instantiable};
 use crate::{
-    symmetric_crypto::{key::SymmetricKey, nonce::Nonce, Dem},
-    RandomFixedSizeCBytes,
+    symmetric_crypto::{nonce::Nonce, Dem},
+    RandomFixedSizeCBytes, SymmetricKey,
 };
 
 /// Structure implementing `SymmetricCrypto` and the `DEM` interfaces based on
@@ -88,10 +88,9 @@ mod tests {
     use crate::{
         reexport::rand_core::SeedableRng,
         symmetric_crypto::{
-            aes_256_gcm::Aes256Gcm, dem::DemStream, key::SymmetricKey, nonce::Nonce, Dem,
-            DemInPlace, Instantiable,
+            aes_256_gcm::Aes256Gcm, dem::DemStream, nonce::Nonce, Dem, DemInPlace, Instantiable,
         },
-        CryptoCoreError, CsRng, FixedSizeCBytes, RandomFixedSizeCBytes,
+        CryptoCoreError, CsRng, FixedSizeCBytes, RandomFixedSizeCBytes, SymmetricKey,
     };
 
     #[test]

--- a/src/symmetric_crypto/chacha20_poly1305.rs
+++ b/src/symmetric_crypto/chacha20_poly1305.rs
@@ -7,11 +7,10 @@ use chacha20poly1305::ChaCha20Poly1305 as ChaCha20Poly1305Lib;
 
 use super::{
     dem::{DemStream, Instantiable},
-    key::SymmetricKey,
     nonce::Nonce,
     Dem, DemInPlace,
 };
-use crate::RandomFixedSizeCBytes;
+use crate::{RandomFixedSizeCBytes, SymmetricKey};
 
 pub struct ChaCha20Poly1305(ChaCha20Poly1305Lib);
 
@@ -90,11 +89,10 @@ mod tests {
         symmetric_crypto::{
             chacha20_poly1305::ChaCha20Poly1305,
             dem::{DemStream, Instantiable},
-            key::SymmetricKey,
             nonce::Nonce,
             Dem, DemInPlace,
         },
-        CryptoCoreError, CsRng, FixedSizeCBytes, RandomFixedSizeCBytes,
+        CryptoCoreError, CsRng, FixedSizeCBytes, RandomFixedSizeCBytes, SymmetricKey,
     };
 
     #[test]

--- a/src/symmetric_crypto/mod.rs
+++ b/src/symmetric_crypto/mod.rs
@@ -8,7 +8,6 @@ mod aes_256_gcm;
 #[cfg(feature = "chacha")]
 mod chacha20_poly1305;
 mod dem;
-mod key;
 #[cfg(feature = "rfc5649")]
 mod key_wrapping_rfc_5649;
 mod nonce;
@@ -22,7 +21,6 @@ pub use aes_256_gcm::Aes256Gcm;
 #[cfg(feature = "chacha")]
 pub use chacha20_poly1305::ChaCha20Poly1305;
 pub use dem::{Dem, DemInPlace, DemStream, Instantiable};
-pub use key::SymmetricKey;
 #[cfg(feature = "rfc5649")]
 pub use key_wrapping_rfc_5649::{key_unwrap, key_unwrap_64, key_wrap, key_wrap_64};
 pub use nonce::Nonce;

--- a/src/symmetric_crypto/xchacha20_poly1305.rs
+++ b/src/symmetric_crypto/xchacha20_poly1305.rs
@@ -7,11 +7,10 @@ use chacha20poly1305::XChaCha20Poly1305 as XChaCha20Poly1305Lib;
 
 use super::{
     dem::{DemStream, Instantiable},
-    key::SymmetricKey,
     nonce::Nonce,
     Dem, DemInPlace,
 };
-use crate::RandomFixedSizeCBytes;
+use crate::{RandomFixedSizeCBytes, SymmetricKey};
 
 pub struct XChaCha20Poly1305(XChaCha20Poly1305Lib);
 
@@ -89,12 +88,11 @@ mod tests {
         reexport::rand_core::SeedableRng,
         symmetric_crypto::{
             dem::{DemStream, Instantiable},
-            key::SymmetricKey,
             nonce::Nonce,
             xchacha20_poly1305::XChaCha20Poly1305,
             Dem, DemInPlace,
         },
-        CryptoCoreError, CsRng, FixedSizeCBytes, RandomFixedSizeCBytes,
+        CryptoCoreError, CsRng, FixedSizeCBytes, RandomFixedSizeCBytes, SymmetricKey,
     };
 
     #[test]


### PR DESCRIPTION
This does not force any dependency and should be fast to compile. Tree-shaking should be able to strip binaries from it if unused.