### PR TITLE
add the `define_byte_type!` macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,6 +317,7 @@ dependencies = [
  "digest",
  "ed25519-dalek",
  "elliptic-curve",
+ "gensym",
  "getrandom 0.2.15",
  "leb128",
  "libc",
@@ -744,6 +745,18 @@ dependencies = [
  "typenum",
  "version_check",
  "zeroize",
+]
+
+[[package]]
+name = "gensym"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913dce4c5f06c2ea40fc178c06f777ac89fc6b1383e90c254fafb1abe4ba3c82"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ default = [
 ]
 ecies = ["aead", "crypto_box"]
 rsa = ["digest", "dep:rsa", "sha1", "sha2", "dep:sha3", "pkcs8", "rfc5649"]
+macro = ["gensym"]
 nist_curves = ["p384", "p256", "p224", "p192", "elliptic-curve", "pkcs8"]
 rfc5649 = ["aes", "chacha"]
 ser = ["leb128"]
@@ -64,6 +65,7 @@ elliptic-curve = { version = "0.13.8", default-features = false, features = [
   "pkcs8",
   "ecdh",
 ], optional = true }
+gensym = { version = "0.1.1", optional = true }
 getrandom = { version = "0.2", features = ["js"] } # needed to compile into WASM
 leb128 = { version = "0.2", optional = true }
 p192 = { version = "0.13", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ default = [
 ]
 ecies = ["aead", "crypto_box"]
 rsa = ["digest", "dep:rsa", "sha1", "sha2", "dep:sha3", "pkcs8", "rfc5649"]
-macro = ["gensym"]
+macro = ["gensym", "ser"]
 nist_curves = ["p384", "p256", "p224", "p192", "elliptic-curve", "pkcs8"]
 rfc5649 = ["aes", "chacha"]
 ser = ["leb128"]

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -107,13 +107,12 @@ macro_rules! _define_byte_type {
 
 #[cfg(test)]
 mod tests {
-    use std::ops::Deref;
-
     use crate::{
         bytes_ser_de::test_serialization, CBytes, CryptoCoreError, CsRng, FixedSizeCBytes,
         RandomFixedSizeCBytes, Sampling,
     };
     use rand_core::SeedableRng;
+    use std::ops::Deref;
 
     /// Defines two new byte types (thus asserting definitions are hygienic),
     /// test their serializations and implement some more stuff for one of them

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1,10 +1,13 @@
+pub use gensym;
+
 #[macro_export]
 macro_rules! define_byte_type {
     ($name: ident) => {
-        gensym::gensym! { _define_byte_type! { $name } }
+        $crate::bytes::gensym::gensym! { $crate::_define_byte_type! { $name } }
     };
 }
 
+#[macro_export]
 macro_rules! _define_byte_type {
     ($module: ident, $name: ident) => {
         pub use $module::$name;
@@ -15,9 +18,9 @@ macro_rules! _define_byte_type {
 
             use std::ops::{Deref, DerefMut};
 
-            use rand_core::RngCore;
-
-            use crate::{bytes_ser_de::Serializable, CryptoCoreError, Sampling};
+            use $crate::{
+                bytes_ser_de::Serializable, reexport::rand_core::RngCore, CryptoCoreError, Sampling,
+            };
 
             impl<const LENGTH: usize> Deref for $name<LENGTH> {
                 type Target = [u8; LENGTH];
@@ -30,6 +33,12 @@ macro_rules! _define_byte_type {
             impl<const LENGTH: usize> DerefMut for $name<LENGTH> {
                 fn deref_mut(&mut self) -> &mut Self::Target {
                     &mut self.0
+                }
+            }
+
+            impl<const LENGTH: usize> AsRef<[u8]> for $name<LENGTH> {
+                fn as_ref(&self) -> &[u8] {
+                    &**self
                 }
             }
 
@@ -56,12 +65,12 @@ macro_rules! _define_byte_type {
 
                 fn write(
                     &self,
-                    ser: &mut crate::bytes_ser_de::Serializer,
+                    ser: &mut $crate::bytes_ser_de::Serializer,
                 ) -> Result<usize, Self::Error> {
                     ser.write_array(&self.0)
                 }
 
-                fn read(de: &mut crate::bytes_ser_de::Deserializer) -> Result<Self, Self::Error> {
+                fn read(de: &mut $crate::bytes_ser_de::Deserializer) -> Result<Self, Self::Error> {
                     de.read_array::<LENGTH>().map(Self)
                 }
             }

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1,0 +1,122 @@
+#[macro_export]
+macro_rules! define_byte_type {
+    ($name: ident) => {
+        gensym::gensym! { _define_byte_type! { $name } }
+    };
+}
+
+macro_rules! _define_byte_type {
+    ($module: ident, $name: ident) => {
+        pub use $module::$name;
+
+        mod $module {
+            #[derive(Debug, Clone, Hash, PartialEq, Eq)]
+            pub struct $name<const LENGTH: usize>([u8; LENGTH]);
+
+            use std::ops::{Deref, DerefMut};
+
+            use rand_core::RngCore;
+
+            use crate::{bytes_ser_de::Serializable, CryptoCoreError, Sampling};
+
+            impl<const LENGTH: usize> Deref for $name<LENGTH> {
+                type Target = [u8; LENGTH];
+
+                fn deref(&self) -> &Self::Target {
+                    &self.0
+                }
+            }
+
+            impl<const LENGTH: usize> DerefMut for $name<LENGTH> {
+                fn deref_mut(&mut self) -> &mut Self::Target {
+                    &mut self.0
+                }
+            }
+
+            impl<const LENGTH: usize> From<[u8; LENGTH]> for $name<LENGTH> {
+                fn from(bytes: [u8; LENGTH]) -> Self {
+                    Self(bytes)
+                }
+            }
+
+            impl<const LENGTH: usize> Sampling for $name<LENGTH> {
+                fn random(rng: &mut impl RngCore) -> Self {
+                    let mut bytes = [0; LENGTH];
+                    rng.fill_bytes(&mut bytes);
+                    Self(bytes)
+                }
+            }
+
+            impl<const LENGTH: usize> Serializable for $name<LENGTH> {
+                type Error = CryptoCoreError;
+
+                fn length(&self) -> usize {
+                    LENGTH
+                }
+
+                fn write(
+                    &self,
+                    ser: &mut crate::bytes_ser_de::Serializer,
+                ) -> Result<usize, Self::Error> {
+                    ser.write_array(&self.0)
+                }
+
+                fn read(de: &mut crate::bytes_ser_de::Deserializer) -> Result<Self, Self::Error> {
+                    de.read_array::<LENGTH>().map(Self)
+                }
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Deref;
+
+    use crate::{
+        bytes_ser_de::test_serialization, CBytes, CryptoCoreError, CsRng, FixedSizeCBytes,
+        RandomFixedSizeCBytes, Sampling,
+    };
+    use rand_core::SeedableRng;
+
+    /// Defines two new byte types (thus asserting definitions are hygienic),
+    /// test their serializations and implement some more stuff for one of them
+    /// to prove enough is implemented by default for the defined byte types to
+    /// be actually usable.
+    #[test]
+    fn test_bytes() {
+        define_byte_type!(B1);
+        define_byte_type!(B2);
+
+        impl CBytes for B2<32> {}
+
+        impl FixedSizeCBytes<32> for B2<32> {
+            const LENGTH: usize = 32;
+
+            fn to_bytes(&self) -> [u8; 32] {
+                *self.deref()
+            }
+
+            fn try_from_bytes(bytes: [u8; 32]) -> Result<Self, CryptoCoreError> {
+                Ok(Self::from(bytes))
+            }
+        }
+
+        impl RandomFixedSizeCBytes<32> for B2<32> {
+            fn new<R: rand_core::CryptoRngCore>(rng: &mut R) -> Self {
+                Self::random(rng)
+            }
+
+            fn as_bytes(&self) -> &[u8] {
+                &**self
+            }
+        }
+
+        let mut rng = CsRng::from_entropy();
+        let b1 = B1::<32>::random(&mut rng);
+        let b2 = B2::<32>::new(&mut rng);
+
+        test_serialization(&b1).unwrap();
+        test_serialization(&b2).unwrap();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,9 @@
 mod asymmetric_crypto;
 #[cfg(feature = "blake")]
 pub mod blake2;
+#[cfg(feature = "macro")]
+#[macro_use]
+mod bytes;
 #[cfg(feature = "ser")]
 pub mod bytes_ser_de;
 #[cfg(feature = "ecies")]
@@ -65,6 +68,11 @@ pub fn shuffle<X: Clone>(xs: &[X], rng: &mut impl CryptoRngCore) -> Vec<X> {
     let mut res = xs.to_vec();
     shuffle_in_place(&mut res, rng);
     res
+}
+
+/// A uniform sampling functionality.
+pub trait Sampling {
+    fn random(rng: &mut impl CryptoRngCore) -> Self;
 }
 
 /// Cryptographic bytes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ mod asymmetric_crypto;
 pub mod blake2;
 #[cfg(feature = "macro")]
 #[macro_use]
-mod bytes;
+pub mod bytes;
 #[cfg(feature = "ser")]
 pub mod bytes_ser_de;
 #[cfg(feature = "ecies")]


### PR DESCRIPTION
Convenient macro that can be used to enforce strong typing on bytes without overhead!

See its test as an example of use:
```    fn test_bytes() {
        define_byte_type!(B1);
        define_byte_type!(B2);

        impl CBytes for B2<32> {}

        impl FixedSizeCBytes<32> for B2<32> {
            const LENGTH: usize = 32;

            fn to_bytes(&self) -> [u8; 32] {
                *self.deref()
            }

            fn try_from_bytes(bytes: [u8; 32]) -> Result<Self, CryptoCoreError> {
                Ok(Self::from(bytes))
            }
        }

        impl RandomFixedSizeCBytes<32> for B2<32> {
            fn new<R: rand_core::CryptoRngCore>(rng: &mut R) -> Self {
                Self::random(rng)
            }

            fn as_bytes(&self) -> &[u8] {
                &**self
            }
        }

        let mut rng = CsRng::from_entropy();
        let b1 = B1::<32>::random(&mut rng);
        let b2 = B2::<32>::new(&mut rng);

        test_serialization(&b1).unwrap();
        test_serialization(&b2).unwrap();
```